### PR TITLE
chore(security): remove dev secrets; add Cursor rules and MCP servers

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,29 @@
+{
+  "mcpServers": {
+    "sequential-thinking": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking"
+      ]
+    },
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-playwright"
+      ],
+      "disabled": false
+    },
+    "serena": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "serena-mcp-server"
+      ],
+      "disabled": false
+    }
+  }
+}
+
+

--- a/.cursor/rules/01-project-structure.mdc
+++ b/.cursor/rules/01-project-structure.mdc
@@ -1,0 +1,37 @@
+---
+alwaysApply: true
+---
+# AI.ProfilePhotoMaker — Project Structure Guide
+
+This workspace is a full-stack app with an ASP.NET Core API and an Angular UI.
+
+## Back end (C#/.NET 8)
+- API root: [AI.ProfilePhotoMaker.API/](mdc:AI.ProfilePhotoMaker.API)
+- Entry point and composition root: [Program.cs](mdc:AI.ProfilePhotoMaker.API/Program.cs)
+- Environment validation: [Configuration/EnvironmentConfiguration.cs](mdc:AI.ProfilePhotoMaker.API/Configuration/EnvironmentConfiguration.cs)
+- Database config & DI: [Extensions/DatabaseServiceExtensions.cs](mdc:AI.ProfilePhotoMaker.API/Extensions/DatabaseServiceExtensions.cs)
+- Data layer: [Data/](mdc:AI.ProfilePhotoMaker.API/Data)
+- Controllers: [Controllers/](mdc:AI.ProfilePhotoMaker.API/Controllers)
+- Services: [Services/](mdc:AI.ProfilePhotoMaker.API/Services)
+- Storage providers: [Services/Storage/](mdc:AI.ProfilePhotoMaker.API/Services/Storage)
+- Migrations: [Migrations/](mdc:AI.ProfilePhotoMaker.API/Migrations)
+- Webhook security filter: [Filters/ReplicateSignatureValidationAttribute.cs](mdc:AI.ProfilePhotoMaker.API/Filters/ReplicateSignatureValidationAttribute.cs)
+
+## Front end (Angular)
+- UI root: [AI.ProfilePhotoMaker.UI/](mdc:AI.ProfilePhotoMaker.UI)
+- Angular workspace: [angular.json](mdc:AI.ProfilePhotoMaker.UI/angular.json)
+- Dev proxy: [proxy.conf.json](mdc:AI.ProfilePhotoMaker.UI/proxy.conf.json)
+- Environments: [src/environments/](mdc:AI.ProfilePhotoMaker.UI/src/environments)
+- Auth interceptors/services: [src/app/interceptors/](mdc:AI.ProfilePhotoMaker.UI/src/app/interceptors), [src/app/services/](mdc:AI.ProfilePhotoMaker.UI/src/app/services)
+
+## Tests
+- API unit/integration: [AI.ProfilePhotoMaker.API.Tests/](mdc:AI.ProfilePhotoMaker.API.Tests)
+- API Playwright: [AI.ProfilePhotoMaker.API/tests/playwright/](mdc:AI.ProfilePhotoMaker.API/tests/playwright)
+- UI integration specs: [AI.ProfilePhotoMaker.UI/src/app/integration-tests/](mdc:AI.ProfilePhotoMaker.UI/src/app/integration-tests)
+
+## Deployment & Ops
+- Simple GitHub workflow: [.github/workflows/simple-deploy.yml](mdc:.github/workflows/simple-deploy.yml)
+- Infra as code (Bicep): [infrastructure/](mdc:infrastructure)
+- Deployment docs: [docs/deployment/](mdc:docs/deployment)
+
+Follow thin-controller/service-first patterns. Prefer minimal, targeted edits; preserve existing abstractions and naming.

--- a/.cursor/rules/02-security-and-config.mdc
+++ b/.cursor/rules/02-security-and-config.mdc
@@ -1,0 +1,33 @@
+---
+alwaysApply: true
+---
+# Security, Configuration, and Secrets Handling
+
+Use environment variables, .NET user-secrets, or Azure Key Vault for sensitive config. Never commit secrets to source.
+
+## Configuration Sources
+- API config files: [AI.ProfilePhotoMaker.API/appsettings*.json](mdc:AI.ProfilePhotoMaker.API/appsettings.json)
+- Environment loader: [Program.cs → LoadEnvironmentVariables](mdc:AI.ProfilePhotoMaker.API/Program.cs)
+- Validation (fails fast): [Configuration/EnvironmentConfiguration.cs](mdc:AI.ProfilePhotoMaker.API/Configuration/EnvironmentConfiguration.cs)
+
+Required (per environment validation):
+- `MSSQL_SA_PASSWORD` or `ConnectionStrings__DefaultConnection`
+- `JWT_SECRET`
+- `REPLICATE_API_TOKEN` and `REPLICATE_WEBHOOK_SECRET`
+
+Optional (warn-only):
+- Stripe keys, Google OAuth, Azure Storage
+
+## Development Settings
+- Keep placeholders in `appsettings.Development.json`. Supply real values via user-secrets or `.env` (gitignored).
+- API runs on `http://0.0.0.0:5032` (dev profile). Angular dev server proxies `/api` to 5032.
+
+## Secret Scanning & Hygiene
+- No hardcoded keys in UI or API. Move any literals to env-driven config.
+- Stripe publishable key must not be hardcoded in UI services; obtain from config endpoint or build env.
+
+## Webhook Security
+- Replicate webhooks must pass signature validation: [Filters/ReplicateSignatureValidationAttribute.cs](mdc:AI.ProfilePhotoMaker.API/Filters/ReplicateSignatureValidationAttribute.cs)
+
+## Health/Readiness
+- Health endpoints: [Controllers/HealthController.cs](mdc:AI.ProfilePhotoMaker.API/Controllers/HealthController.cs)

--- a/.cursor/rules/03-local-run.mdc
+++ b/.cursor/rules/03-local-run.mdc
@@ -1,0 +1,25 @@
+---
+alwaysApply: true
+---
+# Local Run Cheatsheet
+
+## Prerequisites
+- Ensure required env vars present via user-secrets or `.env` in repo root. Minimal set:
+  - `MSSQL_SA_PASSWORD` (for local SQL container) or `ConnectionStrings__DefaultConnection`
+  - `JWT_SECRET`
+  - `REPLICATE_API_TOKEN`, `REPLICATE_WEBHOOK_SECRET` (can use dummy values for dev)
+
+## Start API (Development)
+- Launch profile `https` exposes: `https://0.0.0.0:7173; http://0.0.0.0:5032`
+- File: [Properties/launchSettings.json](mdc:AI.ProfilePhotoMaker.API/Properties/launchSettings.json)
+
+## Start UI (Angular)
+- Dev server on `http://localhost:4200` with proxy to API: [proxy.conf.json](mdc:AI.ProfilePhotoMaker.UI/proxy.conf.json)
+- Scripts: [package.json](mdc:AI.ProfilePhotoMaker.UI/package.json)
+
+## Health Checks
+- Basic: `GET /api/health`
+- Readiness: `GET /api/health/ready`
+- Liveness: `GET /api/health/live`
+- Simple: `GET /health`
+- Controller: [Controllers/HealthController.cs](mdc:AI.ProfilePhotoMaker.API/Controllers/HealthController.cs)

--- a/.cursor/rules/prd.mdc
+++ b/.cursor/rules/prd.mdc
@@ -1,5 +1,62 @@
 ---
-description:
-globs:
 alwaysApply: false
+description: Product Requirements (PRD) summary for AI.ProfilePhotoMaker; endpoints, flows, limits; source-linked to PRD
 ---
+
+# Product Requirements — AI.ProfilePhotoMaker (Summary Rule)
+
+Full PRD: [docs/product/PRD.md](mdc:docs/product/PRD.md)
+
+## Summary
+- Tech: ASP.NET Core Web API + Angular; EF Core SQL Server; optional Azure Blob.
+- Core features: Auth, image uploads, training ZIP, custom model training (Replicate), styled generation, enhancement, credits/purchases, retention and deletion.
+- Privacy: originals deleted after 7 days, generated after 30 days.
+
+## Core Endpoints (by area)
+- Auth: `/api/auth/*` → [AuthController.cs](mdc:AI.ProfilePhotoMaker.API/Controllers/AuthController.cs)
+- Profile: `/api/profile/*` and `/api/profile-management/*` → [ProfileController.cs](mdc:AI.ProfilePhotoMaker.API/Controllers/ProfileController.cs), [ProfileManagementController.cs](mdc:AI.ProfilePhotoMaker.API/Controllers/ProfileManagementController.cs)
+- Image: `/api/image/*` → [ImageController.cs](mdc:AI.ProfilePhotoMaker.API/Controllers/ImageController.cs)
+- Style: `/api/style/*` → [StyleController.cs](mdc:AI.ProfilePhotoMaker.API/Controllers/StyleController.cs)
+- Replicate: `/api/replicate/*` → [ReplicateController.cs](mdc:AI.ProfilePhotoMaker.API/Controllers/ReplicateController.cs)
+- Credit: `/api/credit/*` → [CreditController.cs](mdc:AI.ProfilePhotoMaker.API/Controllers/CreditController.cs)
+- Retention: `/api/retentionpolicy/*` → [RetentionPolicyController.cs](mdc:AI.ProfilePhotoMaker.API/Controllers/RetentionPolicyController.cs)
+- Webhooks: `/api/webhooks/replicate/*` → [ReplicateWebhookController.cs](mdc:AI.ProfilePhotoMaker.API/Controllers/ReplicateWebhookController.cs)
+- Health: `/api/health*` and `/health` → [HealthController.cs](mdc:AI.ProfilePhotoMaker.API/Controllers/HealthController.cs)
+
+## Key Business Rules & Limits
+- Uploads: max 20 files/request; per-file ≤ 10MB; allowed: jpg/jpeg/png/webp; magic-bytes verification.
+- Training ZIP: requires ≥ 10 original uploads; auto or manual creation.
+- Credits:
+  - Weekly (Basic): 3; reset every 7 days.
+  - Costs: enhancement=1; model_training=15; styled_generation=5 per image.
+  - Consume credits after successful Replicate call.
+- Generation: 1–4 outputs per style per request; batch supported; validate model availability.
+- Retention: originals 7 days, generated 30 days; background cleanup + manual endpoints.
+
+## External Services & Security
+- Replicate API: training/generation/enhancement; webhook signature validation with 5‑minute window.
+  - Token/secret via env: `REPLICATE_API_TOKEN`, `REPLICATE_WEBHOOK_SECRET`.
+  - Signature validation filter: [ReplicateSignatureValidationAttribute.cs](mdc:AI.ProfilePhotoMaker.API/Filters/ReplicateSignatureValidationAttribute.cs)
+- Stripe: dev uses simulation; real keys optional; webhook handler present in services.
+- Storage: Azure Blob or Local chosen by connection string.
+- Auth: JWT (and Google OAuth when configured). 401 returns JSON (no redirects).
+
+## Acceptance Criteria (MVP highlights)
+- Upload validation/limits enforced; returns absolute URLs.
+- Training ZIP created when threshold met; returns public URL.
+- Training requires 15 purchased credits unless READY model exists.
+- Generation requires purchased credits (5/output) and handles model unavailability.
+- Enhancement uses 1 weekly credit.
+- Retention jobs set and enforce 7/30-day deletion; manual endpoints operational.
+- Credit status/packages/purchase/history endpoints behave as specified; PaymentIntent mocked in dev.
+- Webhooks persist generated images and schedule retention.
+
+## Observability & Non‑PII Logging
+- Structured logs around uploads, credit usage, training/generation, webhooks, retention.
+- Do not log PII/tokens/image contents.
+
+## Pointers
+- Composition root & env loading: [Program.cs](mdc:AI.ProfilePhotoMaker.API/Program.cs)
+- Config validation: [Configuration/EnvironmentConfiguration.cs](mdc:AI.ProfilePhotoMaker.API/Configuration/EnvironmentConfiguration.cs)
+- Storage providers: [Services/Storage/*](mdc:AI.ProfilePhotoMaker.API/Services/Storage)
+- Payment (simulation): [CreditController.cs](mdc:AI.ProfilePhotoMaker.API/Controllers/CreditController.cs), [StripePaymentService.cs](mdc:AI.ProfilePhotoMaker.API/Services/Payment/StripePaymentService.cs)

--- a/AI.ProfilePhotoMaker.API/appsettings.Development.json
+++ b/AI.ProfilePhotoMaker.API/appsettings.Development.json
@@ -1,12 +1,12 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost,1433;Database=AIProfileMaker;User Id=sa;Password=Dev123456!;TrustServerCertificate=true;MultipleActiveResultSets=true;",
+    "DefaultConnection": "${DATABASE_CONNECTION_STRING}",
     "AzureStorage": "UseDevelopmentStorage=true"
   },
   "JWT": {
     "ValidAudience": "http://localhost:4200",
     "ValidIssuer": "http://localhost:5032", 
-    "Secret": "this-is-a-test-secret-key-for-development-purposes-only-make-sure-its-long-enough"
+    "Secret": "REPLACE_WITH_DEV_JWT_SECRET"
   },
   "Replicate": {
     "FluxTrainingModelId": "replicate/fast-flux-trainer:e65b43286cf1fc648ebac89c32149769637c0410f5346b97c251cdbc3fc3da1a",


### PR DESCRIPTION
Summary\n- Replace dev secrets in  with placeholders (user-secrets/.env driven).\n- Add  with sequential-thinking, playwright, serena MCP servers.\n- Add  for project structure, security/config, and local run.\n\nRisk\n- Low; no runtime behavior changes beyond config placeholders.\n\nValidation\n- API builds and runs locally;  returns Healthy after user-secrets update.\n- UI builds locally.\n