### PR TITLE
fix(ui): skip /style-preview/list in production

### DIFF
--- a/AI.ProfilePhotoMaker.UI/src/app/services/style-preview.service.ts
+++ b/AI.ProfilePhotoMaker.UI/src/app/services/style-preview.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, BehaviorSubject, catchError, of, map } from 'rxjs';
 import { ConfigService } from './config.service';
+import { environment } from '../../environments/environment';
 
 export interface StylePreviewResponse {
   success: boolean;
@@ -83,7 +84,13 @@ export class StylePreviewService {
     // First, pre-populate cache with known style preview URLs from Azure Blob Storage
     this.prePopulateKnownStyles();
 
-    // Then try to load from API to get the latest data
+    // In production, skip the extra API call and rely on direct Azure URLs
+    if (environment.production) {
+      this._allPreviewsSubject.next(new Map(this._urlCache));
+      return;
+    }
+
+    // In non-production, try to load from API to get the latest data
     const apiUrl = `${this._config.getApiUrl()}/style-preview/list`;
 
     this._http


### PR DESCRIPTION
Skip the extra style previews API call in production and rely on direct Azure Blob URLs.\n\nWhy\n- Avoids 404s from /api/style-preview/list in prod.\n- Service already caches direct URLs; /api/style remains the source for style metadata.\n\nChange\n- In StylePreviewService.loadAllPreviews(), return early in production after pre-populating direct URLs.\n\nRisk\n- Low; only avoids an optional prefetch call.\n