### PR TITLE
ci: build and push images in deploy workflow

### DIFF
--- a/.github/workflows/simple-deploy.yml
+++ b/.github/workflows/simple-deploy.yml
@@ -78,6 +78,18 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: 🐳 Login to ACR
+        run: |
+          az acr login --name aipmcrv16j74jubocuukg
+
+      - name: 🏗️ Build Docker images (backend/frontend)
+        run: |
+          IMAGE_TAG=latest ./scripts/build-local.sh
+
+      - name: 📤 Push Docker images to ACR
+        run: |
+          IMAGE_TAG=latest ./scripts/push-to-acr.sh
           
       - name: 🏗️ Ensure Resource Group
         run: |

--- a/AI.ProfilePhotoMaker.API/tests/playwright/tests/07-no-style-preview-api.spec.ts
+++ b/AI.ProfilePhotoMaker.API/tests/playwright/tests/07-no-style-preview-api.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import { FRONTEND_APP_URL } from './test-data';
+
+test.describe('Production homepage network - no style-preview API calls', () => {
+  test('does not call /api/style-preview/* on load', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    const requestedUrls: string[] = [];
+    page.on('request', req => {
+      requestedUrls.push(req.url());
+    });
+
+    await page.goto(FRONTEND_APP_URL, { waitUntil: 'networkidle' });
+    // Allow any late network to settle
+    await page.waitForTimeout(2000);
+
+    const offending = requestedUrls.filter(u => /\/api\/style-preview(\/|$)/i.test(u));
+    expect(offending, 'No /api/style-preview calls should occur in production').toHaveLength(0);
+  });
+});
+
+


### PR DESCRIPTION
Adds ACR login, Docker build, and push steps to Simple Deploy workflow so new images are published before infra updates.\nAlso adds a Playwright test to assert no /api/style-preview calls in production homepage load.