### PR TITLE
ci: fix frontend Dockerfile build command

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -13,8 +13,8 @@ RUN npm ci
 # Copy source code
 COPY AI.ProfilePhotoMaker.UI/ ./
 
-# Build the Angular application
-RUN npm run build:v1
+# Build the Angular application (production)
+RUN npm run build:prod
 
 # Production stage with nginx
 FROM nginx:alpine


### PR DESCRIPTION
Use npm run build:prod instead of build:v1 in Dockerfile.frontend to match package.json scripts and fix CI image build failure.