### PR TITLE
build(ui): switch to build:mvp-v1 across Docker/CI

### DIFF
--- a/.github/workflows/simple-deploy.yml
+++ b/.github/workflows/simple-deploy.yml
@@ -55,7 +55,7 @@ jobs:
           cd AI.ProfilePhotoMaker.UI
           npm ci
           npm run lint:errors-only
-          npm run build:prod
+          npm run build:mvp-v1
 
   deploy:
     name: 🚀 Simple Deploy

--- a/AI.ProfilePhotoMaker.UI/package.json
+++ b/AI.ProfilePhotoMaker.UI/package.json
@@ -13,7 +13,6 @@
     "build": "npm run lint && ng build",
     "build:dev": "npm run lint && ng build --configuration development",
     "build:mvp-v1": "npm run lint && ng build --configuration mvp-v1",
-    "build:prod": "npm run lint && ng build --configuration production",
     "_comment_testing": "=== TESTING SCRIPTS ===",
     "test": "ng test",
     "test:integration": "ng test --karma-config=karma.integration.conf.js",

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -13,8 +13,8 @@ RUN npm ci
 # Copy source code
 COPY AI.ProfilePhotoMaker.UI/ ./
 
-# Build the Angular application (production)
-RUN npm run build:prod
+# Build the Angular application (MVP v1)
+RUN npm run build:mvp-v1
 
 # Production stage with nginx
 FROM nginx:alpine


### PR DESCRIPTION
Use build:mvp-v1 for Angular app in Dockerfile and CI tests. Remove build:prod to avoid divergence. Checked angular.json for mvp-v1 config and environment replacements.