### PR TITLE
Critical Fix: OAuth Configuration Fallback Logic

### DIFF
--- a/AI.ProfilePhotoMaker.API/Controllers/AuthController.cs
+++ b/AI.ProfilePhotoMaker.API/Controllers/AuthController.cs
@@ -105,7 +105,8 @@ namespace AI.ProfilePhotoMaker.API.Controllers
                 return BadRequest(new { error = $"{provider} OAuth not implemented yet" });
             }
 
-            var clientId = _configuration["Authentication:Google:ClientId"] ?? Environment.GetEnvironmentVariable("GOOGLE_CLIENT_ID");
+            var configClientId = _configuration["Authentication:Google:ClientId"];
+            var clientId = string.IsNullOrEmpty(configClientId) ? Environment.GetEnvironmentVariable("GOOGLE_CLIENT_ID") : configClientId;
             if (string.IsNullOrEmpty(clientId))
             {
                 return BadRequest(new { error = "Google OAuth is not configured" });
@@ -192,8 +193,10 @@ namespace AI.ProfilePhotoMaker.API.Controllers
 
         private async Task<GoogleTokenResponse?> ExchangeCodeForTokenAsync(string code)
         {
-            var clientId = _configuration["Authentication:Google:ClientId"] ?? Environment.GetEnvironmentVariable("GOOGLE_CLIENT_ID");
-            var clientSecret = _configuration["Authentication:Google:ClientSecret"] ?? Environment.GetEnvironmentVariable("GOOGLE_CLIENT_SECRET");
+            var configClientId = _configuration["Authentication:Google:ClientId"];
+            var configClientSecret = _configuration["Authentication:Google:ClientSecret"];
+            var clientId = string.IsNullOrEmpty(configClientId) ? Environment.GetEnvironmentVariable("GOOGLE_CLIENT_ID") : configClientId;
+            var clientSecret = string.IsNullOrEmpty(configClientSecret) ? Environment.GetEnvironmentVariable("GOOGLE_CLIENT_SECRET") : configClientSecret;
             var backendBaseUrl = $"{Request.Scheme}://{Request.Host}";
             var redirectUri = $"{backendBaseUrl}/api/auth/external-login-callback";
 

--- a/AI.ProfilePhotoMaker.API/Program.cs
+++ b/AI.ProfilePhotoMaker.API/Program.cs
@@ -108,27 +108,24 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
     options.KnownProxies.Add(System.Net.IPAddress.Parse("127.0.0.1"));
 });
 
-// Configure data protection and session for OAuth state handling
-if (builder.Environment.IsDevelopment())
-{
-    builder.Services.AddDataProtection()
-        .PersistKeysToFileSystem(new DirectoryInfo(Path.Combine(builder.Environment.ContentRootPath, "keys")))
-        .SetApplicationName("AI.ProfilePhotoMaker.API");
+// Configure data protection for OAuth state handling
+builder.Services.AddDataProtection()
+    .PersistKeysToFileSystem(new DirectoryInfo(Path.Combine(builder.Environment.ContentRootPath, "keys")))
+    .SetApplicationName("AI.ProfilePhotoMaker.API");
 
-    // Add session services for OAuth state management
-    builder.Services.AddMemoryCache();
-    builder.Services.AddDistributedMemoryCache();
-    builder.Services.AddSession(options =>
-    {
-        options.IdleTimeout = TimeSpan.FromMinutes(30);
-        options.Cookie.HttpOnly = true;
-        options.Cookie.IsEssential = true;
-        options.Cookie.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None; // Allow cross-site for OAuth
-        options.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.Always;
-        // Don't specify domain - let browser handle same-origin cookies
-        options.Cookie.Domain = null;
-    });
-}
+// Add session services for OAuth state management (required for both Development and Production)
+builder.Services.AddMemoryCache();
+builder.Services.AddDistributedMemoryCache();
+builder.Services.AddSession(options =>
+{
+    options.IdleTimeout = TimeSpan.FromMinutes(30);
+    options.Cookie.HttpOnly = true;
+    options.Cookie.IsEssential = true;
+    options.Cookie.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None; // Allow cross-site for OAuth
+    options.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.Always;
+    // Don't specify domain - let browser handle same-origin cookies
+    options.Cookie.Domain = null;
+});
 
 // Add services to the container.
 
@@ -171,8 +168,10 @@ builder.Services.Configure<IdentityOptions>(options =>
 });
 
 // Only add Google OAuth if properly configured
-var googleClientId = builder.Configuration["Authentication:Google:ClientId"] ?? Environment.GetEnvironmentVariable("GOOGLE_CLIENT_ID");
-var googleClientSecret = builder.Configuration["Authentication:Google:ClientSecret"] ?? Environment.GetEnvironmentVariable("GOOGLE_CLIENT_SECRET");
+var configClientId = builder.Configuration["Authentication:Google:ClientId"];
+var configClientSecret = builder.Configuration["Authentication:Google:ClientSecret"];
+var googleClientId = string.IsNullOrEmpty(configClientId) ? Environment.GetEnvironmentVariable("GOOGLE_CLIENT_ID") : configClientId;
+var googleClientSecret = string.IsNullOrEmpty(configClientSecret) ? Environment.GetEnvironmentVariable("GOOGLE_CLIENT_SECRET") : configClientSecret;
 
 // Add JWT Authentication with Cookie support for OAuth
 var authBuilder = builder.Services.AddAuthentication(options =>
@@ -512,11 +511,8 @@ app.Use(async (context, next) =>
     await next();
 });
 
-// Use session middleware for OAuth state management
-if (app.Environment.IsDevelopment())
-{
-    app.UseSession();
-}
+// Use session middleware for OAuth state management (required for both environments)
+app.UseSession();
 
 // Configure middleware
 if (app.Environment.IsDevelopment())


### PR DESCRIPTION
## Summary
- Fix critical OAuth configuration fallback bug preventing environment variable usage
- Resolve 500 Internal Server Error on OAuth endpoints in production
- Enable session middleware for both Development and Production environments

## Problem Fixed
The OAuth authentication was failing in production due to a critical bug in the configuration fallback logic:
- Configuration API returns **empty strings** instead of null values
- Null-coalescing operator `??` only triggers on null, not empty strings  
- This prevented fallback to environment variables, causing OAuth to fail

## Solution
- Replace `??` with `string.IsNullOrEmpty()` checks for proper fallback logic
- Apply fix to both `AuthController.cs` and `Program.cs`
- Enable session middleware for all environments (required for OAuth state management)

## Code Changes
**AuthController.cs:**
```csharp
// Before (broken):
var clientId = _configuration["Authentication:Google:ClientId"] ?? Environment.GetEnvironmentVariable("GOOGLE_CLIENT_ID");

// After (fixed):
var configClientId = _configuration["Authentication:Google:ClientId"];
var clientId = string.IsNullOrEmpty(configClientId) ? Environment.GetEnvironmentVariable("GOOGLE_CLIENT_ID") : configClientId;
```

**Program.cs:**
- Session middleware now enabled for both Development and Production
- OAuth configuration uses same `string.IsNullOrEmpty()` pattern

## Business Impact
- **High Priority**: Unblocks user authentication in production
- **Critical**: Enables new user registration via Google OAuth
- **Revenue**: Restores user acquisition capability

## Test Plan
- [x] Build succeeds locally
- [x] OAuth works in local development
- [ ] Deploy to production via CI/CD
- [ ] Run Playwright OAuth validation tests
- [ ] Verify OAuth endpoint returns 302 redirect (not 500 error)
- [ ] Confirm Google OAuth flow completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)