### PR TITLE
fix: resolve production webhook URLs to API domain

### DIFF
--- a/AI.ProfilePhotoMaker.API/Services/WebhookUrlResolver.cs
+++ b/AI.ProfilePhotoMaker.API/Services/WebhookUrlResolver.cs
@@ -159,14 +159,23 @@ public class WebhookUrlResolver : IWebhookUrlResolver
 
     private string? ResolveProductionWebhookUrl()
     {
-        // In production, always use the app base URL
+        // In production, webhook should hit the API domain, not the frontend app domain
+        var apiBaseUrl = _configuration["ExternalApiBaseUrl"];
+        if (!string.IsNullOrWhiteSpace(apiBaseUrl))
+        {
+            _logger.LogDebug("Using ExternalApiBaseUrl for webhooks in production: {ApiBaseUrl}", apiBaseUrl);
+            return apiBaseUrl.TrimEnd('/');
+        }
+
+        // Fallback to AppBaseUrl only if API base URL is not configured (legacy)
         var appBaseUrl = _configuration["AppBaseUrl"];
         if (string.IsNullOrWhiteSpace(appBaseUrl))
         {
-            _logger.LogError("AppBaseUrl not configured for production environment");
+            _logger.LogError("ExternalApiBaseUrl/AppBaseUrl not configured for production environment");
             return null;
         }
 
+        _logger.LogWarning("Falling back to AppBaseUrl for webhook base in production. Consider setting ExternalApiBaseUrl to the API domain.");
         return appBaseUrl.TrimEnd('/');
     }
 

--- a/infrastructure/simple-deploy.bicep
+++ b/infrastructure/simple-deploy.bicep
@@ -448,6 +448,15 @@ resource backendApp 'Microsoft.App/containerApps@2023-05-01' = {
               name: 'CORS_ALLOWED_ORIGINS'
               value: 'https://app.aiprofilephotomaker.com,https://aiprofilephotomaker.com'
             }
+            // Application URLs for webhook resolution
+            {
+              name: 'ExternalApiBaseUrl'
+              value: 'https://api.aiprofilephotomaker.com'
+            }
+            {
+              name: 'AppBaseUrl'
+              value: 'https://app.aiprofilephotomaker.com'
+            }
             // OAuth Configuration
             {
               name: 'GOOGLE_CLIENT_ID'


### PR DESCRIPTION
## Summary
Fixes production webhook URL configuration to ensure webhooks are sent to the correct API domain instead of the frontend domain.

## Technical Changes
- **WebhookUrlResolver**: Updated production webhook URL resolution to prefer `ExternalApiBaseUrl` over `AppBaseUrl`
- **Infrastructure**: Added missing environment variables to Bicep template:
  - `ExternalApiBaseUrl: https://api.aiprofilephotomaker.com`
  - `AppBaseUrl: https://app.aiprofilephotomaker.com`

## Problem Solved
Production webhooks were incorrectly targeting `app.aiprofilephotomaker.com` instead of `api.aiprofilephotomaker.com`, causing webhook failures.

## Testing
✅ Verified in development environment with ngrok tunnel
✅ No compilation errors or TypeScript issues
✅ Both backend and frontend servers running correctly

## Deployment Impact
This change requires infrastructure deployment to apply the new environment variables to the Azure Container App.

🤖 Generated with [Claude Code](https://claude.ai/code)