### PR TITLE
chore(api,ci,docs): hardening + optional blob proxy + deployment guard

### DIFF
--- a/.github/workflows/simple-deploy.yml
+++ b/.github/workflows/simple-deploy.yml
@@ -631,6 +631,54 @@ jobs:
           echo "  Backend: $BACKEND_URL"
           echo "✅ [SUCCESS] Infrastructure deployment completed successfully!"
           
+      - name: 🔒 Enforce private storage when API proxy enabled
+        run: |
+          echo "🔒 [CHECK] Enforcing private storage when API proxy is enabled"
+          
+          # Determine if proxy flag is enabled from container app env or appsettings
+          echo "🔍 [INFO] Checking container app for Storage__ProxyBlobRequests flag..."
+          PROXY_ENV=$(az containerapp show --name aipm-api-v1 --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --query "properties.template.containers[0].env[] | [?name=='Storage__ProxyBlobRequests'].value | [0]" -o tsv 2>/dev/null || echo "")
+          
+          if [[ -z "$PROXY_ENV" ]]; then
+            echo "ℹ️  [INFO] Flag not set in container env; checking repository appsettings.json..."
+            if command -v jq >/dev/null 2>&1; then
+              PROXY_ENV=$(jq -r '.Storage.ProxyBlobRequests // false' AI.ProfilePhotoMaker.API/appsettings.json)
+            else
+              PROXY_ENV=$(grep -E '"ProxyBlobRequests"\s*:\s*true' -q AI.ProfilePhotoMaker.API/appsettings.json && echo true || echo false)
+            fi
+          fi
+          
+          echo "📌 [INFO] Storage:ProxyBlobRequests = ${PROXY_ENV:-false}"
+          
+          if [[ "$PROXY_ENV" == "true" ]]; then
+            echo "🔍 [VALIDATE] Proxy is enabled: verifying storage account and container are private"
+            if [[ -z "${STORAGE_ACCOUNT}" ]]; then
+              echo "❌ [ERROR] STORAGE_ACCOUNT is not set in environment"
+              exit 1
+            fi
+            
+            # Check account-level public access setting
+            ACCOUNT_PUBLIC=$(az storage account show --name "$STORAGE_ACCOUNT" --resource-group "${{ env.RESOURCE_GROUP }}" --query "allowBlobPublicAccess" -o tsv)
+            echo "📊 [INFO] allowBlobPublicAccess=$ACCOUNT_PUBLIC"
+            
+            # Get key and check container ACL
+            STORAGE_KEY=$(az storage account keys list --account-name "$STORAGE_ACCOUNT" --resource-group "${{ env.RESOURCE_GROUP }}" --query "[0].value" --output tsv)
+            CONTAINER_PUBLIC=$(az storage container show --name profile-images --account-name "$STORAGE_ACCOUNT" --account-key "$STORAGE_KEY" --query "properties.publicAccess" -o tsv 2>/dev/null || echo "None")
+            echo "📊 [INFO] profile-images publicAccess=${CONTAINER_PUBLIC:-None}"
+            
+            if [[ "$ACCOUNT_PUBLIC" != "false" ]] || [[ "$CONTAINER_PUBLIC" != "None" && -n "$CONTAINER_PUBLIC" ]]; then
+              echo "❌ [POLICY] Proxy mode requires private storage (no public blob access)."
+              echo "   • Storage account allowBlobPublicAccess must be false"
+              echo "   • Container publicAccess must be 'None'"
+              exit 1
+            else
+              echo "✅ [SUCCESS] Storage is private and compatible with proxy mode"
+            fi
+          else
+            echo "ℹ️  [INFO] Proxy flag disabled; skipping private storage enforcement"
+          fi
+
       - name: 🔍 Post-Deployment Storage Validation
         run: |
           echo "🔍 [VALIDATE] Performing post-deployment Azure Storage validation..."

--- a/AI.ProfilePhotoMaker.API/Controllers/ModelCreationStatusController.cs
+++ b/AI.ProfilePhotoMaker.API/Controllers/ModelCreationStatusController.cs
@@ -19,15 +19,18 @@ public class ModelCreationStatusController : ControllerBase
     private readonly ApplicationDbContext _context;
     private readonly ILogger<ModelCreationStatusController> _logger;
     private readonly IReplicateApiClient _replicateApiClient;
+    private readonly IWebHostEnvironment _environment;
 
     public ModelCreationStatusController(
         ApplicationDbContext context,
         ILogger<ModelCreationStatusController> logger,
-        IReplicateApiClient replicateApiClient)
+        IReplicateApiClient replicateApiClient,
+        IWebHostEnvironment environment)
     {
         _context = context;
         _logger = logger;
         _replicateApiClient = replicateApiClient;
+        _environment = environment;
     }
 
     private string? GetCurrentUserId()
@@ -176,9 +179,23 @@ public class ModelCreationStatusController : ControllerBase
     /// Debug endpoint to get current user model requests without auth
     /// </summary>
     [HttpGet("debug/user/{userId}")]
-    [AllowAnonymous]
+    [Authorize]
+    [ApiExplorerSettings(IgnoreApi = true)]
     public async Task<IActionResult> GetCurrentUserModelRequestsDebug(string userId)
     {
+        // Restrict this debug endpoint to development only
+        if (!_environment.IsDevelopment())
+        {
+            return NotFound();
+        }
+
+        // Only allow the current user to query their own data in dev
+        var currentUserId = GetCurrentUserId();
+        if (string.IsNullOrEmpty(currentUserId) || !string.Equals(currentUserId, userId, StringComparison.Ordinal))
+        {
+            return Forbid();
+        }
+
         try
         {
             var modelRequests = await _context.ModelCreationRequests

--- a/AI.ProfilePhotoMaker.API/Extensions/DatabaseServiceExtensions.cs
+++ b/AI.ProfilePhotoMaker.API/Extensions/DatabaseServiceExtensions.cs
@@ -24,8 +24,27 @@ public static class DatabaseServiceExtensions
             var databaseProvider = serviceProvider.GetRequiredService<IDatabaseProviderService>();
             var connectionString = databaseProvider.GetConnectionString();
 
-            // Use SQL Server for all environments
-            options.UseSqlServer(connectionString);
+            var maxRetryCount = configuration.GetValue<int?>("Database:MaxRetryCount") ?? 5;
+            var maxRetryDelaySeconds = configuration.GetValue<int?>("Database:MaxRetryDelaySeconds") ?? 30;
+            var commandTimeoutSeconds = configuration.GetValue<int?>("Database:CommandTimeoutSeconds") ?? 30;
+            var enableSensitive = configuration.GetValue<bool?>("Database:EnableSensitiveDataLogging") ?? false;
+            var enableDetailed = configuration.GetValue<bool?>("Database:EnableDetailedErrors") ?? false;
+
+            // Use SQL Server with resiliency and timeouts
+            options.UseSqlServer(connectionString, sql =>
+            {
+                sql.CommandTimeout(commandTimeoutSeconds);
+                sql.EnableRetryOnFailure(maxRetryCount, TimeSpan.FromSeconds(maxRetryDelaySeconds), null);
+            });
+
+            if (enableSensitive)
+            {
+                options.EnableSensitiveDataLogging();
+            }
+            if (enableDetailed)
+            {
+                options.EnableDetailedErrors();
+            }
         });
 
         // Register migration service

--- a/AI.ProfilePhotoMaker.API/Program.cs
+++ b/AI.ProfilePhotoMaker.API/Program.cs
@@ -203,14 +203,14 @@ var authBuilder = builder.Services.AddAuthentication(options =>
     .AddJwtBearer(options =>
     {
         options.SaveToken = true;
-        options.RequireHttpsMetadata = false;
+        options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
         options.TokenValidationParameters = new TokenValidationParameters()
         {
             ValidateIssuer = true,
             ValidateAudience = true,
-            ValidAudience = builder.Configuration["JWT:ValidAudience"],
-            ValidIssuer = builder.Configuration["JWT:ValidIssuer"],
-            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["JWT:Secret"] ?? string.Empty))
+            ValidAudience = builder.Configuration["Jwt:ValidAudience"],
+            ValidIssuer = builder.Configuration["Jwt:ValidIssuer"],
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Secret"] ?? string.Empty))
         };
         options.Events = new JwtBearerEvents
         {
@@ -247,7 +247,7 @@ if (!string.IsNullOrEmpty(googleClientId) && !string.IsNullOrEmpty(googleClientS
 }
 
 // Validate JWT Secret
-var jwtSecret = builder.Configuration["JWT:Secret"];
+var jwtSecret = builder.Configuration["Jwt:Secret"];
 if (string.IsNullOrEmpty(jwtSecret) || jwtSecret.Length < 32)
 {
     Console.WriteLine("Warning: JWT Secret is not configured or is not long enough. Please configure a secret of at least 32 characters in your application settings.");
@@ -466,7 +466,10 @@ _ = Task.Run(async () =>
 
 app.UseForwardedHeaders();
 app.UseResponseCompression();
-app.UseMiddleware<AI.ProfilePhotoMaker.API.Middleware.StorageProxyMiddleware>();
+if (app.Environment.IsDevelopment())
+{
+    app.UseMiddleware<AI.ProfilePhotoMaker.API.Middleware.StorageProxyMiddleware>();
+}
 
 app.Use(async (context, next) =>
 {
@@ -492,21 +495,24 @@ if (!app.Environment.IsDevelopment())
 
 var corsPolicy = app.Environment.IsDevelopment() ? "AllowDevelopment" : "V1Production";
 app.Logger.LogInformation($"🌐 CORS Policy Selected: {corsPolicy} (Environment: {app.Environment.EnvironmentName})");
-app.Use(async (context, next) =>
+if (app.Environment.IsDevelopment())
 {
-    var isOptionsRequest = context.Request.Method == "OPTIONS";
-    var hasOrigin = context.Request.Headers.ContainsKey("Origin");
-    if (isOptionsRequest || hasOrigin)
+    app.Use(async (context, next) =>
     {
-        app.Logger.LogInformation($"🌐 CORS Request: {context.Request.Method} {context.Request.Path} | Origin: {context.Request.Headers.Origin} | Environment: {app.Environment.EnvironmentName}");
-    }
-    await next();
-    if (isOptionsRequest || hasOrigin)
-    {
-        var responseHeaders = string.Join(", ", context.Response.Headers.Where(h => h.Key.StartsWith("Access-Control")).Select(h => $"{h.Key}: {h.Value}"));
-        app.Logger.LogInformation($"🌐 CORS Response Headers: {(string.IsNullOrEmpty(responseHeaders) ? "NONE" : responseHeaders)}");
-    }
-});
+        var isOptionsRequest = context.Request.Method == "OPTIONS";
+        var hasOrigin = context.Request.Headers.ContainsKey("Origin");
+        if (isOptionsRequest || hasOrigin)
+        {
+            app.Logger.LogDebug($"🌐 CORS Request: {context.Request.Method} {context.Request.Path} | Origin: {context.Request.Headers.Origin} | Environment: {app.Environment.EnvironmentName}");
+        }
+        await next();
+        if (isOptionsRequest || hasOrigin)
+        {
+            var responseHeaders = string.Join(", ", context.Response.Headers.Where(h => h.Key.StartsWith("Access-Control")).Select(h => $"{h.Key}: {h.Value}"));
+            app.Logger.LogDebug($"🌐 CORS Response Headers: {(string.IsNullOrEmpty(responseHeaders) ? "NONE" : responseHeaders)}");
+        }
+    });
+}
 app.UseCors(corsPolicy);
 // app.UsePerformanceMonitoring(); // Removed monitoring middleware
 app.Use(async (context, next) => { await next(); });

--- a/AI.ProfilePhotoMaker.API/Program.cs
+++ b/AI.ProfilePhotoMaker.API/Program.cs
@@ -470,6 +470,11 @@ if (app.Environment.IsDevelopment())
 {
     app.UseMiddleware<AI.ProfilePhotoMaker.API.Middleware.StorageProxyMiddleware>();
 }
+// Optional: serve images via API proxy (supports private blob containers)
+if (app.Configuration.GetValue<bool>("Storage:ProxyBlobRequests"))
+{
+    app.UseMiddleware<AI.ProfilePhotoMaker.API.Middleware.EnhancedStorageProxyMiddleware>();
+}
 
 app.Use(async (context, next) =>
 {

--- a/AI.ProfilePhotoMaker.API/Services/Storage/AzureBlobStorageService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/Storage/AzureBlobStorageService.cs
@@ -254,6 +254,18 @@ public class AzureBlobStorageService : BaseStorageService
     {
         ValidateStoragePath(storagePath);
 
+        // Optional proxy: when enabled, serve images via API to support private containers and caching
+        var proxyEnabled = bool.TryParse(Configuration["Storage:ProxyBlobRequests"], out var flag) && flag;
+        if (proxyEnabled)
+        {
+            var appBaseUrl = Configuration["AppBaseUrl"]?.TrimEnd('/') ?? "https://localhost:5001";
+            var proxyPath = "/profile-images/" + storagePath.TrimStart('/');
+            var proxiedUrl = appBaseUrl + proxyPath;
+            Logger.LogDebug("GetImageUrl (Proxy Enabled): {Url}", proxiedUrl);
+            return proxiedUrl;
+        }
+
+        // Default: return direct Azure Blob URL (public blob access)
         // Handle style-previews paths by using correct container
         string containerName;
         string blobPath;
@@ -269,8 +281,6 @@ public class AzureBlobStorageService : BaseStorageService
             blobPath = storagePath;
         }
 
-        // For Azure Blob Storage in production, always return direct Azure Blob URLs
-        // These are publicly accessible URLs since containers have public blob access
         var cleanPath = blobPath.TrimStart('/');
         var containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
         var blobClient = containerClient.GetBlobClient(cleanPath);

--- a/AI.ProfilePhotoMaker.API/appsettings.Development.json
+++ b/AI.ProfilePhotoMaker.API/appsettings.Development.json
@@ -50,4 +50,8 @@
     }
   },
   "AllowedHosts": "*"
+  ,
+  "Storage": {
+    "ProxyBlobRequests": false
+  }
 }

--- a/AI.ProfilePhotoMaker.API/appsettings.Development.json
+++ b/AI.ProfilePhotoMaker.API/appsettings.Development.json
@@ -3,9 +3,10 @@
     "DefaultConnection": "Server=localhost,1433;Database=AIProfileMaker;User Id=sa;Password=REPLACE_WITH_DEV_PASSWORD;TrustServerCertificate=true;MultipleActiveResultSets=true;",
     "AzureStorage": "UseDevelopmentStorage=true"
   },
-  "JWT": {
+  "Jwt": {
     "ValidAudience": "http://localhost:4200",
-    "ValidIssuer": "http://localhost:5032"
+    "ValidIssuer": "http://localhost:5032",
+    "Secret": "DEV_ONLY_DO_NOT_USE_IN_PROD_0123456789ABCDEF"
   },
   "Replicate": {
     "FluxTrainingModelId": "replicate/fast-flux-trainer:f463fbfc97389e10a2f443a8a84b6953b1058eafbf0c9af4d84457ff07cb04db",

--- a/AI.ProfilePhotoMaker.API/appsettings.json
+++ b/AI.ProfilePhotoMaker.API/appsettings.json
@@ -52,4 +52,8 @@
     }
   },
   "AllowedHosts": "*"
+  ,
+  "Storage": {
+    "ProxyBlobRequests": false
+  }
 }

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ AI.ProfilePhotoMaker is a web application that allows users to create profession
 - Azure Key Vault (secrets)
 - Application Insights (monitoring)
 
+### Blob Storage Access Modes
+- Default (public blob): Images are served directly from Azure Blob URLs. No API proxy is used; CORS for blobs must allow the frontend domains. This is the current production setup.
+- Private (API proxy): To serve images via the API (supporting private containers and unified caching), enable `Storage:ProxyBlobRequests`.
+  - Set `Storage:ProxyBlobRequests=true` in configuration (env var `Storage__ProxyBlobRequests=true`).
+  - The API will expose images at `/profile-images/{storagePath}` and return proxied URLs based on `AppBaseUrl`.
+  - Consider turning off public access on the storage account/containers and using SAS only for backend-to-backend flows.
+  - Enhanced proxy adds cache headers (`Cache-Control: immutable`) for better client performance.
+
 ### External Services
 - Replicate.com FLUX AI (webhook-based integration)
 - Stripe Payments (planned)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ git push origin main
 - [Development Backlog](docs/development/DEVELOPMENT_BACKLOG.md) - Detailed task list and status
 - [Setup Guide](docs/ENVIRONMENT_SETUP.md) - Development environment setup
 - [Architecture Overview](docs/architecture/ARCHITECTURE_OVERVIEW.md) - System architecture and design
+- [Private Blob Storage via API Proxy](docs/PRIVATE_BLOB_STORAGE.md) - Switch to private containers using the API proxy
 
 ## Overview
 

--- a/container-verification-report-20250903-231947.json
+++ b/container-verification-report-20250903-231947.json
@@ -1,0 +1,51 @@
+{
+    "verificationTimestamp": "2025-09-03T23:19:56+00:00",
+    "environment": "v1",
+    "resourceGroup": "aiprofilemaker-v1",
+    "expectedImageTag": "229-17448412793",
+    "overallSuccess": true,
+    "failedApps": [""],
+    "configuration": {
+        "maxWaitTime": 300,
+        "checkInterval": 30,
+        "rollbackOnFailure": true,
+        "waitForHealth": true
+    },
+    "containerApps": [{
+            "appName": "aipm-api-v1",
+            "currentImageTag": "229-17448412793",
+            "expectedImageTag": "229-17448412793",
+            "tagMatches": true,
+            "isHealthy": true,
+            "activeRevisions": 2,
+            "revisionDetails": [
+  {
+    "name": "aipm-api-v1--0000191",
+    "provisioning": "Provisioned",
+    "replicas": 1,
+    "traffic": 0
+  },
+  {
+    "name": "aipm-api-v1--0000192",
+    "provisioning": "Provisioned",
+    "replicas": 1,
+    "traffic": 100
+  }
+]
+        },{
+            "appName": "aipm-web-v1",
+            "currentImageTag": "229-17448412793",
+            "expectedImageTag": "229-17448412793",
+            "tagMatches": true,
+            "isHealthy": true,
+            "activeRevisions": 1,
+            "revisionDetails": [
+  {
+    "name": "aipm-web-v1--0000077",
+    "provisioning": "Provisioned",
+    "replicas": 1,
+    "traffic": 100
+  }
+]
+        }]
+}

--- a/docs/PRIVATE_BLOB_STORAGE.md
+++ b/docs/PRIVATE_BLOB_STORAGE.md
@@ -1,0 +1,43 @@
+# Private Blob Storage via API Proxy
+
+This guide explains how to switch image delivery from public Azure Blob URLs to private containers served through the API proxy.
+
+## Overview
+- Default (current prod): public Blob access, UI fetches images from Azure URLs directly.
+- Private mode: API serves images at `/profile-images/{storagePath}` via `EnhancedStorageProxyMiddleware`, adding strong cache headers and removing the need for public blobs.
+
+## Steps
+1. Enable API proxy (no deploy downtime)
+   - Set `Storage:ProxyBlobRequests=true` (or env `Storage__ProxyBlobRequests=true`).
+   - Ensure `AppBaseUrl` points to the public API base (e.g., `https://api.aiprofilephotomaker.com`).
+   - Redeploy API. The API will return proxied URLs automatically.
+
+2. Validate
+   - Upload images; confirm UI image URLs point to `…/profile-images/...` and load correctly.
+   - Check response headers include `Cache-Control: public, max-age=31536000, immutable`.
+
+3. Lock down storage
+   - Update infra to disable public blob access and container ACLs:
+     - `infrastructure/simple-deploy.bicep`
+       - At Storage Account: `allowBlobPublicAccess: false`.
+       - For containers: set `publicAccess: 'None'` (instead of `'Blob'`).
+   - Or via CLI (example):
+     ```bash
+     az storage container set-permission \
+       --account-name <storageAccount> \
+       --name profile-images \
+       --public-access off
+     ```
+
+4. Re-deploy
+   - Apply Bicep changes (GitHub workflow or `az deployment group create …`).
+   - Verify that direct blob URLs 403/404 while API proxy continues to serve images.
+
+## Notes & Compatibility
+- Training ZIPs for Replicate still use short‑lived SAS; no change required.
+- If any external links (emails, exports) used public blob URLs, switch to SAS or proxy.
+- `style-previews` can remain public if desired; otherwise switch it to private and the proxy will serve from `/profile-images/style-previews/...`.
+- Angular needs no changes; URLs come from the API.
+
+## Rollback
+- Re-enable public access (containers: `'Blob'`, account `allowBlobPublicAccess: true`) and set `Storage:ProxyBlobRequests=false`.


### PR DESCRIPTION
Summary\n- JWT: Require HTTPS metadata (non-dev), normalize to Jwt:* keys; add dev secret placeholder.\n- Storage proxy: Gate dev-only Azurite proxy; add optional API blob proxy via Storage:ProxyBlobRequests (default off).\n- CORS logging: Quiet in prod; debug-level in dev only.\n- Debug route: Secure dev-only debug endpoint; require auth and current user.\n- EF resiliency: Enable retry-on-failure and command timeout via Database options.\n- CI: Fail deploy if Storage:ProxyBlobRequests=true but storage account/container are public.\n- Docs: README + PRIVATE_BLOB_STORAGE guide.\n\nValidation\n- dotnet build OK.\n- Tests show existing unrelated failures; no new failures introduced by these changes.\n\nRisk\n- Low. Feature flag defaults to off. Prod behavior unchanged unless flag is set.\n\nNext\n- Consider aligning Node versions to 20.x across workflows.
