### PR TITLE
Fix: Replicate owner consistency + dev verification endpoint

### DIFF
--- a/AI.ProfilePhotoMaker.API/Controllers/ConfigController.cs
+++ b/AI.ProfilePhotoMaker.API/Controllers/ConfigController.cs
@@ -26,6 +26,49 @@ public class ConfigController : ControllerBase
     }
 
     /// <summary>
+    /// Development-only: surface effective Replicate configuration (safe fields)
+    /// </summary>
+    [HttpGet("replicate/status")]
+    public IActionResult GetReplicateStatus()
+    {
+        if (!_environment.IsDevelopment())
+        {
+            return NotFound();
+        }
+
+        try
+        {
+            var envOwner = Environment.GetEnvironmentVariable("REPLICATE_OWNER");
+            var cfgOwner = _configuration["Replicate:Owner"];
+            var owner = envOwner ?? cfgOwner ?? string.Empty;
+
+            var envHardware = Environment.GetEnvironmentVariable("REPLICATE_HARDWARE");
+            var cfgHardware = _configuration["Replicate:Hardware"];
+            var hardware = envHardware ?? cfgHardware ?? string.Empty;
+
+            var trainingModelId = _configuration["Replicate:FluxTrainingModelId"] ?? string.Empty;
+
+            var status = new
+            {
+                environment = _environment.EnvironmentName,
+                owner = owner,
+                ownerSource = string.IsNullOrEmpty(envOwner) ? "config:Replicate:Owner" : "env:REPLICATE_OWNER",
+                hardware = hardware,
+                hardwareSource = string.IsNullOrEmpty(envHardware) ? "config:Replicate:Hardware" : "env:REPLICATE_HARDWARE",
+                fluxTrainingModelId = trainingModelId,
+                note = "Tokens and secrets are intentionally not exposed in this endpoint"
+            };
+
+            return Ok(new { success = true, data = status, error = (object?)null });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving Replicate configuration status");
+            return StatusCode(500, new { success = false, error = "Failed to retrieve Replicate configuration status" });
+        }
+    }
+
+    /// <summary>
     /// Get client-safe configuration for frontend applications
     /// </summary>
     [HttpGet("client")]

--- a/AI.ProfilePhotoMaker.API/appsettings.Development.json
+++ b/AI.ProfilePhotoMaker.API/appsettings.Development.json
@@ -9,6 +9,7 @@
     "Secret": "DEV_ONLY_DO_NOT_USE_IN_PROD_0123456789ABCDEF"
   },
   "Replicate": {
+    "Owner": "alanw707",
     "FluxTrainingModelId": "replicate/fast-flux-trainer:f463fbfc97389e10a2f443a8a84b6953b1058eafbf0c9af4d84457ff07cb04db",
     "FluxGenerationModelId": "black-forest-labs/flux-dev",
     "FluxKontextProModelId": "black-forest-labs/flux-kontext-pro"

--- a/AI.ProfilePhotoMaker.API/appsettings.json
+++ b/AI.ProfilePhotoMaker.API/appsettings.json
@@ -9,7 +9,7 @@
   },
   "Replicate": {
     "ApiToken": "REPLACE_WITH_PRODUCTION_REPLICATE_TOKEN",
-    "Owner": "REPLACE_WITH_REPLICATE_OWNER",
+    "Owner": "alanw707",
     "Hardware": "gpu-h100",
     "FluxTrainingModelId": "replicate/fast-flux-trainer:f463fbfc97389e10a2f443a8a84b6953b1058eafbf0c9af4d84457ff07cb04db",
     "FluxGenerationModelId": "black-forest-labs/flux-dev",

--- a/infrastructure/simple-deploy.bicep
+++ b/infrastructure/simple-deploy.bicep
@@ -374,6 +374,11 @@ resource backendApp 'Microsoft.App/containerApps@2023-05-01' = {
               name: 'ASPNETCORE_ENVIRONMENT'
               value: 'Production'
             }
+            // Replicate owner is constant across environments to prevent drift
+            {
+              name: 'Replicate__Owner'
+              value: 'alanw707'
+            }
             // Map both ASP.NET Core config pattern and plain env var to the same secret
             {
               name: 'ConnectionStrings__DefaultConnection'


### PR DESCRIPTION
- Set Replicate.Owner=alanw707 in appsettings (prod/dev)
- Enforce owner via Container Apps env (Replicate__Owner) in Bicep to prevent drift
- Added dev-only endpoint GET /api/config/replicate/status to surface effective owner/hardware for verification (no secrets)

Why: Prevent 403 ReplicatePermissionDenied due to owner mismatch in production; keep dev/prod consistent

Dev verified: ENABLE_REPLICATE_MOCK=true, training succeeded, credits deducted, owner reported as alanw707

Follow-up: Update production by rolling revision or re-deploy so env picks up Replicate__Owner; verify /api/replicate/health and start a training