### PR TITLE
fix: correct gallery classification and dev webhook reliability

### DIFF
--- a/AI.ProfilePhotoMaker.API/Controllers/ImageController.cs
+++ b/AI.ProfilePhotoMaker.API/Controllers/ImageController.cs
@@ -53,6 +53,173 @@ namespace AI.ProfilePhotoMaker.API.Controllers
         }
 
         /// <summary>
+        /// Reconcile database image records with backing storage.
+        /// Removes records that reference non-existent files. When dryRun=true, only reports counts.
+        /// </summary>
+        [HttpPost("reconcile-database")]
+        public async Task<IActionResult> ReconcileDatabase([FromQuery] bool dryRun = true)
+        {
+            // Allow anonymous access in development for database maintenance
+            string? userId = null;
+            if (_environment.IsProduction())
+            {
+                var authCheck = ValidateAuthentication();
+                if (authCheck != null) return authCheck;
+                userId = GetCurrentUserId()!;
+            }
+            else
+            {
+                // In development, we'll process all images for cleanup
+                LogInfo("Running reconcile-database in development mode (anonymous access)");
+            }
+
+            try
+            {
+                // Safety guard: never allow destructive reconcile in Production environment
+                if (_environment.IsProduction() && !dryRun)
+                {
+                    return ErrorResponse("Forbidden", "Destructive reconciliation is disabled in production", 403);
+                }
+
+                List<ProcessedImage> allImages;
+                UserProfile? profile = null;
+
+                if (userId != null)
+                {
+                    // Production mode: process images for specific user
+                    profile = await _userProfileRepository.GetByUserIdAsync(userId);
+                    if (profile == null)
+                        return ErrorResponse("ProfileNotFound", "Profile not found", 404);
+                    allImages = profile.ProcessedImages.ToList();
+                }
+                else
+                {
+                    // Development mode: process all images for cleanup
+                    if (Context == null)
+                    {
+                        return ErrorResponse("ServerError", "Database context unavailable", 500);
+                    }
+                    allImages = await Context.ProcessedImages.ToListAsync();
+                }
+
+                var orphaned = new List<ProcessedImage>();
+                var skippedAmbiguous = 0;
+
+                async Task<bool> PathExistsAsync(string? path)
+                {
+                    if (string.IsNullOrEmpty(path)) return false;
+                    if (path.StartsWith("http", StringComparison.OrdinalIgnoreCase)) return true; // cannot verify external URLs; do not mark missing
+                    return await _storageService.ExistsAsync(path);
+                }
+
+                foreach (var img in allImages)
+                {
+                    // If both URLs are missing entirely, this is clearly orphaned
+                    if (string.IsNullOrEmpty(img.OriginalImageUrl) && string.IsNullOrEmpty(img.ProcessedImageUrl))
+                    {
+                        orphaned.Add(img);
+                        continue;
+                    }
+
+                    var isClearlyOriginal = img.IsOriginalUpload && !img.IsGenerated;
+                    var isClearlyGenerated = img.IsGenerated && !img.IsOriginalUpload;
+
+                    // Resolve ambiguous flags using style when possible
+                    if (!isClearlyOriginal && !isClearlyGenerated)
+                    {
+                        if (string.Equals(img.Style, ImageConstants.OriginalStyle, StringComparison.OrdinalIgnoreCase))
+                        {
+                            isClearlyOriginal = true;
+                        }
+                        else if (!string.IsNullOrEmpty(img.Style) && !string.Equals(img.Style, ImageConstants.OriginalStyle, StringComparison.OrdinalIgnoreCase))
+                        {
+                            isClearlyGenerated = true;
+                        }
+                    }
+
+                    // Original uploads must have the original file present; processed file is not required
+                    if (isClearlyOriginal)
+                    {
+                        var originalExists = await PathExistsAsync(img.OriginalImageUrl);
+                        if (!originalExists)
+                        {
+                            orphaned.Add(img);
+                        }
+                        continue;
+                    }
+
+                    // Generated images must have the processed file present; original file is not required
+                    if (isClearlyGenerated)
+                    {
+                        var processedExists = await PathExistsAsync(img.ProcessedImageUrl);
+                        if (!processedExists)
+                        {
+                            orphaned.Add(img);
+                        }
+                        continue;
+                    }
+
+                    // Ambiguous records (cannot confidently classify) — do not delete to avoid data loss
+                    skippedAmbiguous++;
+                }
+
+                if (dryRun)
+                {
+                    // Include fields used by tests/clients even in dry-run
+                    var totalUsersWithImages = allImages.Any() ? 1 : 0; // this endpoint reconciles only current user
+                    return SuccessResponse(new
+                    {
+                        TotalImages = allImages.Count,
+                        OrphanedRecords = orphaned.Count,
+                        OrphanedRecordsRemoved = 0,
+                        TotalUsers = totalUsersWithImages,
+                        SkippedAmbiguousRecords = skippedAmbiguous,
+                        Message = orphaned.Count > 0
+                            ? $"Found {orphaned.Count} orphaned image record(s)"
+                            : "No orphaned image records found",
+                        Timestamp = DateTime.UtcNow
+                    });
+                }
+
+                foreach (var img in orphaned)
+                {
+                    // Only remove from profile if we have a profile (production mode)
+                    if (profile != null)
+                        profile.ProcessedImages.Remove(img);
+                    // Always remove from context in both modes
+                    Context?.ProcessedImages.Remove(img);
+                }
+
+                if (orphaned.Count > 0)
+                {
+                    await Context!.SaveChangesAsync();
+                    // Update repo/caches as well for real application behavior (production mode only)
+                    if (profile != null && _userProfileRepository != null)
+                        await _userProfileRepository.UpdateAsync(profile);
+                    if (userId != null && _userContextService != null)
+                        await _userContextService.InvalidateUserCacheAsync(userId);
+                    LogInfo($"Removed {orphaned.Count} orphaned image records" + (userId != null ? $" for user {userId}" : " (development cleanup)"));
+                }
+
+                return SuccessResponse(new
+                {
+                    TotalImagesChecked = allImages.Count,
+                    OrphanedRecordsRemoved = orphaned.Count,
+                    SkippedAmbiguousRecords = skippedAmbiguous,
+                    Message = orphaned.Count > 0
+                        ? $"Successfully removed {orphaned.Count} orphaned image record(s)"
+                        : "No orphaned image records to remove",
+                    Timestamp = DateTime.UtcNow
+                });
+            }
+            catch (Exception ex)
+            {
+                LogError(ex, "Error reconciling image database", userId);
+                return ErrorResponse("ReconciliationFailed", "Failed to reconcile image database", 500);
+            }
+        }
+
+        /// <summary>
         /// Gets available image styles
         /// </summary>
         [HttpGet("styles")]
@@ -140,30 +307,38 @@ namespace AI.ProfilePhotoMaker.API.Controllers
                     await using var imageStream = image.OpenReadStream();
                     await _storageService.SaveImageToPathAsync(imageStream, storagePath);
 
-                    // Store storage path in DB; URLs are generated per-request
-                    // Persist both original uploads and enhanced images so they appear in the gallery
-                    var processedImage = new ProcessedImage
+                    // For ENHANCEMENT uploads: do NOT create gallery records.
+                    // These are temporary inputs for enhancement workflows.
+                    if (!dto.IsEnhanced)
                     {
-                        OriginalImageUrl = dto.IsEnhanced ? string.Empty : storagePath,
-                        ProcessedImageUrl = storagePath,
-                        Style = dto.IsEnhanced ? "Enhanced" : ImageConstants.OriginalStyle,
-                        UserProfileId = profile.Id,
-                        CreatedAt = DateTime.UtcNow,
-                        IsOriginalUpload = !dto.IsEnhanced,
-                        IsGenerated = dto.IsEnhanced,
-                    };
+                        // Store storage path in DB for original uploads so they appear in the gallery
+                        var processedImage = new ProcessedImage
+                        {
+                            OriginalImageUrl = storagePath,
+                            ProcessedImageUrl = storagePath,
+                            Style = ImageConstants.OriginalStyle,
+                            UserProfileId = profile.Id,
+                            CreatedAt = DateTime.UtcNow,
+                            IsOriginalUpload = true,
+                            IsGenerated = false,
+                        };
 
-                    // Set scheduled deletion date based on retention policy
-                    processedImage.SetScheduledDeletionDate();
+                        // Set scheduled deletion date based on retention policy
+                        processedImage.SetScheduledDeletionDate();
 
-                    profile.ProcessedImages.Add(processedImage);
-                    uploadedImages.Add(processedImage);
+                        profile.ProcessedImages.Add(processedImage);
+                        uploadedImages.Add(processedImage);
 
-                    Logger.LogInformation(
-                        dto.IsEnhanced
-                            ? "Created database record for enhanced image {FileName} for user {UserId}"
-                            : "Created database record for uploaded image {FileName} for user {UserId}",
-                        fileName, userId);
+                        Logger.LogInformation(
+                            "Created database record for uploaded image {FileName} for user {UserId}",
+                            fileName, userId);
+                    }
+                    else
+                    {
+                        Logger.LogInformation(
+                            "Stored temporary enhanced upload (no DB record) {FileName} for user {UserId}",
+                            fileName, userId);
+                    }
 
                     // Return a public URL for the client while keeping storagePath in DB
                     var publicUrl = _storageService.GetImageUrl(storagePath);
@@ -977,171 +1152,7 @@ namespace AI.ProfilePhotoMaker.API.Controllers
             }
         }
 
-        /// <summary>
-        /// Reconcile database image records with backing storage.
-        /// Removes records that reference non-existent files. When dryRun=true, only reports counts.
-        /// </summary>
-        [HttpPost("reconcile-database")]
-        public async Task<IActionResult> ReconcileDatabase([FromQuery] bool dryRun = true)
-        {
-            // Allow anonymous access in development for database maintenance
-            string? userId = null;
-            if (_environment.IsProduction())
-            {
-                var authCheck = ValidateAuthentication();
-                if (authCheck != null) return authCheck;
-                userId = GetCurrentUserId()!;
-            }
-            else 
-            {
-                // In development, we'll process all images for cleanup
-                LogInfo("Running reconcile-database in development mode (anonymous access)");
-            }
-
-            try
-            {
-                // Safety guard: never allow destructive reconcile in Production environment
-                if (_environment.IsProduction() && !dryRun)
-                {
-                    return ErrorResponse("Forbidden", "Destructive reconciliation is disabled in production", 403);
-                }
-
-                List<ProcessedImage> allImages;
-                UserProfile? profile = null;
-                
-                if (userId != null)
-                {
-                    // Production mode: process images for specific user
-                    profile = await _userProfileRepository.GetByUserIdAsync(userId);
-                    if (profile == null)
-                        return ErrorResponse("ProfileNotFound", "Profile not found", 404);
-                    allImages = profile.ProcessedImages.ToList();
-                }
-                else
-                {
-                    // Development mode: process all images for cleanup
-                    if (Context == null)
-                    {
-                        return ErrorResponse("ServerError", "Database context unavailable", 500);
-                    }
-                    allImages = await Context.ProcessedImages.ToListAsync();
-                }
-                var orphaned = new List<ProcessedImage>();
-                var skippedAmbiguous = 0;
-
-                async Task<bool> PathExistsAsync(string? path)
-                {
-                    if (string.IsNullOrEmpty(path)) return false;
-                    if (path.StartsWith("http", StringComparison.OrdinalIgnoreCase)) return true; // cannot verify external URLs; do not mark missing
-                    return await _storageService.ExistsAsync(path);
-                }
-
-                foreach (var img in allImages)
-                {
-                    // If both URLs are missing entirely, this is clearly orphaned
-                    if (string.IsNullOrEmpty(img.OriginalImageUrl) && string.IsNullOrEmpty(img.ProcessedImageUrl))
-                    {
-                        orphaned.Add(img);
-                        continue;
-                    }
-
-                    var isClearlyOriginal = img.IsOriginalUpload && !img.IsGenerated;
-                    var isClearlyGenerated = img.IsGenerated && !img.IsOriginalUpload;
-
-                    // Resolve ambiguous flags using style when possible
-                    if (!isClearlyOriginal && !isClearlyGenerated)
-                    {
-                        if (string.Equals(img.Style, ImageConstants.OriginalStyle, StringComparison.OrdinalIgnoreCase))
-                        {
-                            isClearlyOriginal = true;
-                        }
-                        else if (!string.IsNullOrEmpty(img.Style) && !string.Equals(img.Style, ImageConstants.OriginalStyle, StringComparison.OrdinalIgnoreCase))
-                        {
-                            isClearlyGenerated = true;
-                        }
-                    }
-
-                    // Original uploads must have the original file present; processed file is not required
-                    if (isClearlyOriginal)
-                    {
-                        var originalExists = await PathExistsAsync(img.OriginalImageUrl);
-                        if (!originalExists)
-                        {
-                            orphaned.Add(img);
-                        }
-                        continue;
-                    }
-
-                    // Generated images must have the processed file present; original file is not required
-                    if (isClearlyGenerated)
-                    {
-                        var processedExists = await PathExistsAsync(img.ProcessedImageUrl);
-                        if (!processedExists)
-                        {
-                            orphaned.Add(img);
-                        }
-                        continue;
-                    }
-
-                    // Ambiguous records (cannot confidently classify) — do not delete to avoid data loss
-                    skippedAmbiguous++;
-                }
-
-                if (dryRun)
-                {
-                    // Include fields used by tests/clients even in dry-run
-                    var totalUsersWithImages = allImages.Any() ? 1 : 0; // this endpoint reconciles only current user
-                    return SuccessResponse(new
-                    {
-                        TotalImages = allImages.Count,
-                        OrphanedRecords = orphaned.Count,
-                        OrphanedRecordsRemoved = 0,
-                        TotalUsers = totalUsersWithImages,
-                        SkippedAmbiguousRecords = skippedAmbiguous,
-                        Message = orphaned.Count > 0
-                            ? $"Found {orphaned.Count} orphaned image record(s)"
-                            : "No orphaned image records found",
-                        Timestamp = DateTime.UtcNow
-                    });
-                }
-
-                foreach (var img in orphaned)
-                {
-                    // Only remove from profile if we have a profile (production mode)
-                    if (profile != null)
-                        profile.ProcessedImages.Remove(img);
-                    // Always remove from context in both modes
-                    Context?.ProcessedImages.Remove(img);
-                }
-
-                if (orphaned.Count > 0)
-                {
-                    await Context!.SaveChangesAsync();
-                    // Update repo/caches as well for real application behavior (production mode only)
-                    if (profile != null && _userProfileRepository != null)
-                        await _userProfileRepository.UpdateAsync(profile);
-                    if (userId != null && _userContextService != null)
-                        await _userContextService.InvalidateUserCacheAsync(userId);
-                    LogInfo($"Removed {orphaned.Count} orphaned image records" + (userId != null ? $" for user {userId}" : " (development cleanup)"));
-                }
-
-                return SuccessResponse(new
-                {
-                    TotalImagesChecked = allImages.Count,
-                    OrphanedRecordsRemoved = orphaned.Count,
-                    SkippedAmbiguousRecords = skippedAmbiguous,
-                    Message = orphaned.Count > 0
-                        ? $"Successfully removed {orphaned.Count} orphaned image record(s)"
-                        : "No orphaned image records to remove",
-                    Timestamp = DateTime.UtcNow
-                });
-            }
-            catch (Exception ex)
-            {
-                LogError(ex, "Error reconciling image database", userId);
-                return ErrorResponse("ReconciliationFailed", "Failed to reconcile image database", 500);
-            }
-        }
+        
 
         /// <summary>
         /// Saves enhanced image from base64 data to storage and creates database record

--- a/AI.ProfilePhotoMaker.API/Services/ImageProcessing/ImageDownloadService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/ImageProcessing/ImageDownloadService.cs
@@ -52,7 +52,8 @@ public class ImageDownloadService : IImageDownloadService
             var imageUrl = imageUrls[i];
             // Generate unique filename to prevent overwrites
             var timestamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss-fff");
-            var fileName = $"{style.ToLowerInvariant()}-{timestamp}-{i + 1}.jpg";
+            var baseName = $"{style.ToLowerInvariant().Replace(' ', '-')}-{timestamp}-{i + 1}";
+            var fileName = baseName + ".jpg"; // default, updated after content-type detection
 
             try
             {
@@ -60,6 +61,14 @@ public class ImageDownloadService : IImageDownloadService
                 using var response = await _httpClient.GetAsync(imageUrl);
                 if (response.IsSuccessStatusCode)
                 {
+                    // Pick an extension from response content-type when available
+                    var contentType = response.Content.Headers.ContentType?.MediaType ?? "image/jpeg";
+                    var ext = GetExtensionFromContentType(contentType);
+                    if (!string.IsNullOrEmpty(ext))
+                    {
+                        fileName = baseName + ext; // ensure correct container content-type
+                    }
+
                     using var imageStream = await response.Content.ReadAsStreamAsync();
 
                     // Save directly to blob storage

--- a/AI.ProfilePhotoMaker.UI/src/app/components/photo-gallery/photo-gallery.component.ts
+++ b/AI.ProfilePhotoMaker.UI/src/app/components/photo-gallery/photo-gallery.component.ts
@@ -1,4 +1,12 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { GalleryFilterControlsComponent } from './gallery-filter-controls/gallery-filter-controls.component';
 import { GalleryPaginationComponent } from './gallery-pagination/gallery-pagination.component';
@@ -195,7 +203,7 @@ export interface GalleryImage {
     </div>
   `,
   styleUrls: ['./photo-gallery.component.sass'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PhotoGalleryComponent implements OnInit, OnChanges {
   @Input() images: GalleryImage[] = [];
@@ -307,9 +315,14 @@ export class PhotoGalleryComponent implements OnInit, OnChanges {
   toggleSelection(image: GalleryImage): void {
     const index = this.selectedImages.findIndex(selected => selected.id === image.id);
     if (index > -1) {
-      this.selectedImages.splice(index, 1);
+      // Create a new array without the deselected image to trigger OnPush change detection
+      this.selectedImages = [
+        ...this.selectedImages.slice(0, index),
+        ...this.selectedImages.slice(index + 1),
+      ];
     } else {
-      this.selectedImages.push(image);
+      // Reassign with a new array including the newly selected image
+      this.selectedImages = [...this.selectedImages, image];
     }
   }
 

--- a/AI.ProfilePhotoMaker.UI/src/app/pages/gallery/gallery.component.ts
+++ b/AI.ProfilePhotoMaker.UI/src/app/pages/gallery/gallery.component.ts
@@ -91,12 +91,21 @@ export class GalleryComponent implements OnInit {
 
         this.galleryImages = uniqueImages
           .map((img: ProcessedImage) => {
-            // For generated images, prioritize processedImageUrl; for uploads, use originalImageUrl
-            const preferredUrl = img.isGenerated
-              ? img.processedImageUrl || img.originalImageUrl
-              : img.originalImageUrl || img.processedImageUrl;
+            // Detect enhanced images by style markers
+            const styleLower = (img.style || '').toLowerCase();
+            const isEnhanced =
+              styleLower.startsWith('enhanced') ||
+              img.style === 'Background Remover' ||
+              img.style === 'Social Media' ||
+              img.style === 'Cartoon' ||
+              styleLower.startsWith('enhancement:');
 
-            // Skip images without valid URLs
+            // For generated/enhanced, prioritize processedImageUrl; for uploads, prefer original
+            const preferredUrl =
+              img.isGenerated || isEnhanced
+                ? img.processedImageUrl || img.originalImageUrl
+                : img.originalImageUrl || img.processedImageUrl;
+
             if (!preferredUrl) {
               this._logger.warn('Skipping image with no valid URL', {
                 id: img.id,
@@ -106,20 +115,34 @@ export class GalleryComponent implements OnInit {
               return null;
             }
 
+            const type = isEnhanced
+              ? ('enhanced' as const)
+              : img.isGenerated
+                ? ('generated' as const)
+                : ('original' as const);
+
+            const title = isEnhanced
+              ? 'Enhanced Photo'
+              : img.isGenerated
+                ? `${this.formatStyleName(img.style)} Photo`
+                : 'Uploaded Photo';
+
+            const description = isEnhanced
+              ? 'AI-enhanced photo'
+              : img.isGenerated
+                ? `Generated ${this.formatStyleName(img.style)} style profile photo`
+                : 'Original uploaded image';
+
             return {
               id: img.id,
               url: preferredUrl,
-              thumbnailUrl: preferredUrl, // Use same URL for thumbnails to ensure consistency
-              title: img.isGenerated
-                ? `${this.formatStyleName(img.style)} Photo`
-                : 'Uploaded Photo',
-              description: img.isGenerated
-                ? `Generated ${this.formatStyleName(img.style)} style profile photo`
-                : 'Original uploaded image',
+              thumbnailUrl: preferredUrl,
+              title,
+              description,
               style: img.style || 'original',
               createdAt: new Date(img.createdAt),
               status: 'completed' as const,
-              type: img.isGenerated ? ('generated' as const) : ('original' as const),
+              type,
               downloadUrl: preferredUrl,
             };
           })
@@ -193,11 +216,7 @@ export class GalleryComponent implements OnInit {
 
   async onImageDownload(image: GalleryImage) {
     // Skip enhanced images for now - focus on generated images
-    const isEnhancedImage =
-      image.style === 'Background Remover' ||
-      image.style === 'Social Media' ||
-      image.style === 'Cartoon';
-    if (isEnhancedImage) {
+    if (image.type === 'enhanced') {
       alert(
         `Enhanced image downloads are not yet implemented. Focusing on regular generated images first.\n\nImage: ${image.title} (${image.style})`
       );
@@ -416,13 +435,7 @@ export class GalleryComponent implements OnInit {
     }
 
     // Filter out enhanced images for now
-    const generatedImages = images.filter(img => {
-      const isEnhanced =
-        img.style === 'Background Remover' ||
-        img.style === 'Social Media' ||
-        img.style === 'Cartoon';
-      return !isEnhanced;
-    });
+    const generatedImages = images.filter(img => img.type === 'generated');
 
     const enhancedCount = images.length - generatedImages.length;
 

--- a/cleanup-tool/Program.cs
+++ b/cleanup-tool/Program.cs
@@ -6,79 +6,94 @@ class Program
     static void Main(string[] args)
     {
         string connectionString = "Server=localhost,1433;Database=AIProfileMaker;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=true;";
-        
+
+        var mode = args.Length > 0 ? args[0].ToLowerInvariant() : "preview";
+        Console.WriteLine($"Cleanup mode: {mode} (options: preview | delete-temp-enhanced)");
+
         try
         {
             using (SqlConnection connection = new SqlConnection(connectionString))
             {
                 connection.Open();
                 Console.WriteLine("Connected to database successfully!");
-                
-                // First, check what enhanced images exist
-                string queryCount = @"
-                    SELECT 
-                        COUNT(*) as TotalImages,
-                        COUNT(CASE WHEN Style LIKE '%Enhanced%' OR (IsGenerated = 1 AND IsOriginalUpload = 0 AND Style != 'Original') THEN 1 END) as EnhancedImages
-                    FROM ProcessedImages";
-                
-                using (SqlCommand command = new SqlCommand(queryCount, connection))
+
+                if (mode == "delete-temp-enhanced")
                 {
+                    // Target only temporary enhanced uploads accidentally persisted
+                    string previewQuery = @"
+                        SELECT 
+                            pi.Id,
+                            pi.Style,
+                            pi.IsGenerated,
+                            pi.IsOriginalUpload,
+                            pi.OriginalImageUrl,
+                            pi.ProcessedImageUrl,
+                            pi.CreatedAt
+                        FROM ProcessedImages pi
+                        WHERE (pi.Style = 'Enhanced' OR pi.Style = '')
+                          AND (pi.OriginalImageUrl IS NULL OR pi.OriginalImageUrl = '')
+                          AND (pi.ProcessedImageUrl LIKE '%/enhanced/%' OR pi.ProcessedImageUrl LIKE '%\\\\enhanced\\\\%')
+                        ORDER BY pi.CreatedAt DESC";
+
+                    int candidateCount = 0;
+                    using (SqlCommand command = new SqlCommand(previewQuery, connection))
+                    using (SqlDataReader reader = command.ExecuteReader())
+                    {
+                        Console.WriteLine("\nTemp enhanced upload candidates:");
+                        while (reader.Read())
+                        {
+                            candidateCount++;
+                            Console.WriteLine($"ID: {reader["Id"]}, Style: {reader["Style"]}, URL: {reader["ProcessedImageUrl"]}, Created: {reader["CreatedAt"]}");
+                        }
+                    }
+
+                    Console.WriteLine($"\nCandidates found: {candidateCount}");
+                    if (candidateCount == 0)
+                    {
+                        return;
+                    }
+
+                    Console.Write("\nDelete these records? (y/N): ");
+                    string response = Console.ReadLine() ?? string.Empty;
+                    if (response.Equals("y", StringComparison.OrdinalIgnoreCase) || response.Equals("yes", StringComparison.OrdinalIgnoreCase))
+                    {
+                        string deleteQuery = @"
+                            DELETE FROM ProcessedImages 
+                            WHERE (Style = 'Enhanced' OR Style = '')
+                              AND (OriginalImageUrl IS NULL OR OriginalImageUrl = '')
+                              AND (ProcessedImageUrl LIKE '%/enhanced/%' OR ProcessedImageUrl LIKE '%\\\\enhanced\\\\%')";
+
+                        using (SqlCommand deleteCmd = new SqlCommand(deleteQuery, connection))
+                        {
+                            int deleted = deleteCmd.ExecuteNonQuery();
+                            Console.WriteLine($"Deleted {deleted} records.");
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine("No records deleted.");
+                    }
+                }
+                else
+                {
+                    // Preview summary for all images including enhanced
+                    string queryCount = @"
+                        SELECT 
+                            COUNT(*) as TotalImages,
+                            COUNT(CASE WHEN Style LIKE '%Enhanced%' THEN 1 END) as EnhancedImages,
+                            COUNT(CASE WHEN (Style = 'Enhanced' OR Style = '') AND (OriginalImageUrl IS NULL OR OriginalImageUrl = '') AND (ProcessedImageUrl LIKE '%/enhanced/%' OR ProcessedImageUrl LIKE '%\\\\enhanced\\\\%') THEN 1 END) as TempEnhancedCandidates
+                        FROM ProcessedImages";
+
+                    using (SqlCommand command = new SqlCommand(queryCount, connection))
                     using (SqlDataReader reader = command.ExecuteReader())
                     {
                         if (reader.Read())
                         {
                             Console.WriteLine($"Total Images: {reader["TotalImages"]}");
-                            Console.WriteLine($"Enhanced Images: {reader["EnhancedImages"]}");
+                            Console.WriteLine($"Enhanced Images (any): {reader["EnhancedImages"]}");
+                            Console.WriteLine($"Temp Enhanced Candidates: {reader["TempEnhancedCandidates"]}");
                         }
                     }
-                }
-                
-                // Show the enhanced images details
-                string queryDetails = @"
-                    SELECT 
-                        pi.Id,
-                        pi.Style,
-                        pi.IsGenerated,
-                        pi.IsOriginalUpload,
-                        pi.ProcessedImageUrl,
-                        pi.CreatedAt
-                    FROM ProcessedImages pi
-                    WHERE pi.Style LIKE '%Enhanced%' 
-                       OR (pi.IsGenerated = 1 AND pi.IsOriginalUpload = 0 AND pi.Style != 'Original')
-                    ORDER BY pi.CreatedAt DESC";
-                
-                Console.WriteLine("\nEnhanced Images Found:");
-                using (SqlCommand command = new SqlCommand(queryDetails, connection))
-                {
-                    using (SqlDataReader reader = command.ExecuteReader())
-                    {
-                        while (reader.Read())
-                        {
-                            Console.WriteLine($"ID: {reader["Id"]}, Style: {reader["Style"]}, Generated: {reader["IsGenerated"]}, URL: {reader["ProcessedImageUrl"]}, Created: {reader["CreatedAt"]}");
-                        }
-                    }
-                }
-                
-                // Ask if user wants to delete
-                Console.WriteLine("\nDo you want to delete these enhanced image records? (y/N):");
-                string response = Console.ReadLine();
-                
-                if (response?.ToLower() == "y" || response?.ToLower() == "yes")
-                {
-                    string deleteQuery = @"
-                        DELETE FROM ProcessedImages 
-                        WHERE Style LIKE '%Enhanced%' 
-                           OR (IsGenerated = 1 AND IsOriginalUpload = 0 AND Style != 'Original')";
-                    
-                    using (SqlCommand command = new SqlCommand(deleteQuery, connection))
-                    {
-                        int deletedCount = command.ExecuteNonQuery();
-                        Console.WriteLine($"Deleted {deletedCount} enhanced image records.");
-                    }
-                }
-                else
-                {
-                    Console.WriteLine("No records deleted.");
                 }
             }
         }

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -25,5 +25,8 @@ if $START_UI; then
   bash "$SCRIPT_DIR/scripts/ui-start.sh"
 fi
 
+echo "➡️  Starting ngrok tunnel"
+ngrok http 5032 --domain clear-anteater-usually.ngrok-free.app &
+
 echo "✅ Dev services started (API/UI)."
 

--- a/dev-stop.sh
+++ b/dev-stop.sh
@@ -23,5 +23,8 @@ if $STOP_API; then
   bash "$SCRIPT_DIR/scripts/api-stop.sh"
 fi
 
+echo "➡️  Stopping ngrok tunnel"
+pkill -f ngrok || true
+
 echo "✅ Dev services stopped (API/UI)."
 

--- a/scripts/cleanup-temp-enhanced-uploads.sql
+++ b/scripts/cleanup-temp-enhanced-uploads.sql
@@ -1,0 +1,47 @@
+-- Targeted cleanup for temporary enhanced upload records accidentally persisted to the gallery
+-- Keeps final enhanced outputs (e.g., Style like 'Enhanced-%')
+
+-- Preview candidates
+SELECT 
+    pi.Id,
+    pi.Style,
+    pi.IsGenerated,
+    pi.IsOriginalUpload,
+    pi.OriginalImageUrl,
+    pi.ProcessedImageUrl,
+    pi.CreatedAt,
+    up.UserId
+FROM ProcessedImages pi
+JOIN UserProfiles up ON pi.UserProfileId = up.Id
+WHERE 
+    -- Temp enhanced uploads were saved with plain 'Enhanced' style
+    (pi.Style = 'Enhanced' OR pi.Style = '')
+    AND (pi.OriginalImageUrl IS NULL OR pi.OriginalImageUrl = '')
+    AND (pi.ProcessedImageUrl LIKE '%/enhanced/%' OR pi.ProcessedImageUrl LIKE '%\\enhanced\\%')
+ORDER BY pi.CreatedAt DESC;
+
+-- Count
+SELECT COUNT(*) AS TempEnhancedUploadCount
+FROM ProcessedImages pi
+WHERE 
+    (pi.Style = 'Enhanced' OR pi.Style = '')
+    AND (pi.OriginalImageUrl IS NULL OR pi.OriginalImageUrl = '')
+    AND (pi.ProcessedImageUrl LIKE '%/enhanced/%' OR pi.ProcessedImageUrl LIKE '%\\enhanced\\%');
+
+-- To DELETE the above records, uncomment the transaction block
+/*
+BEGIN TRANSACTION;
+
+DELETE pi
+FROM ProcessedImages pi
+WHERE 
+    (pi.Style = 'Enhanced' OR pi.Style = '')
+    AND (pi.OriginalImageUrl IS NULL OR pi.OriginalImageUrl = '')
+    AND (pi.ProcessedImageUrl LIKE '%/enhanced/%' OR pi.ProcessedImageUrl LIKE '%\\enhanced\\%');
+
+SELECT @@ROWCOUNT AS DeletedRecords;
+
+-- COMMIT; -- Uncomment to commit
+ROLLBACK;   -- Default to rollback to be safe
+*/
+


### PR DESCRIPTION
Summary\n- api: skip persisting temporary enhancement uploads; save generated images using correct extension; restore reconcile endpoint for tests.\n- ui: fix bulk selection count under OnPush; classify Enhanced vs Generated in gallery mapping.\n- dev: start/stop ngrok in dev scripts.\n- ops: add targeted cleanup SQL/tool for accidental enhanced inputs.\n\nValidation\n- Local builds and tests pass.\n- Verified generation, webhook save to Azurite, and gallery display.\n\nNotes\n- No migration changes.\n- Production unaffected; only dev ngrok helper.\n