### PR TITLE
fix(openai): simplify DI + test harness

### DIFF
--- a/AI.ProfilePhotoMaker.API.Tests/Services/OpenAIImageGenerationServiceTests.cs
+++ b/AI.ProfilePhotoMaker.API.Tests/Services/OpenAIImageGenerationServiceTests.cs
@@ -36,7 +36,11 @@ namespace AI.ProfilePhotoMaker.API.Tests.Services
             var logger = NullLogger<OpenAIImageGenerationService>.Instance;
             var storage = new Mock<IStorageService>(MockBehavior.Strict); // not used by this method
 
-            var service = new OpenAIImageGenerationService(httpClient, configuration, logger, storage.Object);
+            // Provide a factory that returns the same mocked HttpClient for both OpenAI and download paths
+            var factory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
+            factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+            var service = new OpenAIImageGenerationService(httpClient, factory.Object, configuration, logger, storage.Object);
 
             // Create a valid 2x2 PNG as source image
             byte[] inputPngBytes;

--- a/AI.ProfilePhotoMaker.API/Services/ImageProcessing/OpenAIImageGenerationService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/ImageProcessing/OpenAIImageGenerationService.cs
@@ -52,25 +52,9 @@ public class OpenAIImageGenerationService : IImageProcessingService
         _logger.LogInformation("OpenAI API configured successfully");
     }
 
-    // Backwards-compatible constructor for tests and simple manual instantiation
-    // Reuses the supplied HttpClient for BOTH OpenAI and download paths
-    // so tests that mock HttpMessageHandler still work without hitting network.
-    public OpenAIImageGenerationService(
-        HttpClient httpClient,
-        IConfiguration configuration,
-        ILogger<OpenAIImageGenerationService> logger,
-        IStorageService storageService)
-        : this(httpClient, new PassthroughHttpClientFactory(httpClient), configuration, logger, storageService)
-    {
-    }
-
-    // IHttpClientFactory that returns the provided client (used for tests)
-    private sealed class PassthroughHttpClientFactory : IHttpClientFactory
-    {
-        private readonly HttpClient _client;
-        public PassthroughHttpClientFactory(HttpClient client) => _client = client;
-        public HttpClient CreateClient(string name) => _client;
-    }
+    // Note: tests should supply an IHttpClientFactory that returns the same mocked HttpClient
+    // to capture both the OpenAI POST and the source image GET. Keeping a single DI constructor
+    // avoids ambiguity and simplifies runtime behavior.
 
     /// <summary>
     /// Enhances photo quality using OpenAI DALL-E image transformation and returns base64 data URL format


### PR DESCRIPTION
- Remove extra constructor and rely on a single DI constructor for OpenAIImageGenerationService.\n- Keep typed HttpClient for OpenAI and a factory-provided client for downloads.\n- Update test to provide IHttpClientFactory that returns the same mocked HttpClient so both download and POST are captured.\n\nNo changes to Replicate/performance tests included in this PR.