### PR TITLE
chore(ci): grant actions: read for notify guard

### DIFF
--- a/.github/workflows/config-drift-monitor.yml
+++ b/.github/workflows/config-drift-monitor.yml
@@ -31,6 +31,7 @@ on:
 permissions:
   contents: read
   issues: write  # For creating drift detection issues
+  actions: read  # Required for github.rest.actions.* APIs in notify guard
 
 # Prevent overlapping runs (manual vs. scheduled) from cancelling each other mid-flight
 concurrency:


### PR DESCRIPTION
Adds actions: read to workflow permissions so the github-script guard can call listWorkflowRuns without 403. Prevents notification job failures.