### PR TITLE
chore(ci): avoid push-run failure with noop job

### DIFF
--- a/.github/workflows/config-drift-monitor.yml
+++ b/.github/workflows/config-drift-monitor.yml
@@ -39,6 +39,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  noop-validate-on-push:
+    name: 🧪 Validate Workflow on Push
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
+    steps:
+      - name: No-op validation
+        run: echo "Workflow file updated on push; skipping operational jobs."
+
   config-drift-detection:
     name: 🔍 Detect Configuration Drift
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a guard job that runs only on push and exits successfully, preventing GitHub from marking a push-triggered validation run as failure when operational jobs are gated.