### PR TITLE
chore: gate legacy paths behind toggles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,31 +1,34 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- `AI.ProfilePhotoMaker.API/`: ASP.NET Core Web API (controllers, services, EF Core, middleware). Configuration in `appsettings*.json`.
-- `AI.ProfilePhotoMaker.API.Tests/`: xUnit tests for API (arranged by feature: `Controllers/`, `Services/`).
-- `AI.ProfilePhotoMaker.UI/`: Angular app (`src/`, `assets/`, unit tests, Playwright/Karma).
-- Root tooling: `docker-compose.yml`, `dev-start.sh` / `dev-stop.sh` / `dev-test.sh`, integration tests (`test-*.py`, `*.spec.ts`), deployment docs in `docs/` and `infrastructure/`.
+- `AI.ProfilePhotoMaker.API/`: ASP.NET Core Web API. Feature folders hold controllers, services, and EF Core models; shared cross-cutting code lives in `Configuration/`, `Constants/`, `Extensions/`, `Filters/`, and `Middleware/`. Data access is managed through `Data/` and `Migrations/`, SignalR hubs reside in `Hubs/`, and operational helpers/scripts are under `Scripts/`. API-specific Playwright checks sit in `tests/playwright/`.
+- `AI.ProfilePhotoMaker.API.Tests/`: xUnit suite organized by concern—`Unit/`, `Integration/`, `Controllers/`, `Services/`, `Infrastructure/`, and `Performance/`—with shared fixtures and builders scoped per folder.
+- `AI.ProfilePhotoMaker.UI/`: Angular front-end (`src/` feature modules, shared UI libraries, and services). Static assets live in `public/` and `.well-known/`; end-to-end setups live in `e2e/`, cross-browser utilities in `cypress/`, and supplementary docs/guides in `docs/`.
+- `tests/`: Repository-level Playwright flows (`tests/e2e`) that validate the combined API + UI experience.
+- `scripts/`: Automation for starting/stopping services, deployment validation, environment setup, and CI tooling.
+- `docs/` & `infrastructure/`: Operational runbooks, deployment guidance, and infrastructure-as-code assets.
 
 ## Build, Test, and Development Commands
-- Full stack: `./dev-start.sh` (runs SQL Server, API on 5032, UI on 4200), `./dev-stop.sh`, quick checks via `./dev-test.sh`.
-- API: `dotnet build AI.ProfilePhotoMaker.sln`, `cd AI.ProfilePhotoMaker.API && dotnet run`, tests with `dotnet test AI.ProfilePhotoMaker.API.Tests`.
-- UI: `cd AI.ProfilePhotoMaker.UI && npm run dev:local` (UI only) or `npm run dev:fullstack:local` (proxy to API); build with `npm run build`; unit tests `npm test`; e2e `npm run playwright:install && npm run test:e2e`.
+- Full stack: `./dev-start.sh` (SQL Server, API on 5032, UI on 4200), `./dev-stop.sh`, and `./dev-test.sh` for smoke checks. Use `./dev-rebuild.sh [--api-only|--ui-only]` to rebuild and restart dev services without touching containers.
+- API: `dotnet build AI.ProfilePhotoMaker.sln`, then `dotnet run --project AI.ProfilePhotoMaker.API/AI.ProfilePhotoMaker.API.csproj` (or `cd AI.ProfilePhotoMaker.API && dotnet run`). Execute `dotnet test AI.ProfilePhotoMaker.API.Tests` for automated coverage. API release validation lives in `AI.ProfilePhotoMaker.API/tests/playwright` (`npm install` then `npx playwright test`).
+- UI: From `AI.ProfilePhotoMaker.UI/`, run `npm run dev:local` for UI-only dev, or `npm run dev:fullstack:local` to proxy to the API. Build with `npm run build` or `npm run build:dev`. Karma/Jasmine unit tests via `npm test`, broader integration suites with `npm run test:integration`, and Playwright coverage through `npm run playwright:install && npm run test:e2e` (variants exist for chrome/mobile/debug).
+- Ops scripts: `scripts/api-start.sh`, `scripts/ui-start.sh`, deployment validation helpers (`scripts/validate-*.sh`), and container tooling support day-to-day workflows.
 
 ## Coding Style & Naming Conventions
-- C# (API): 4‑space indent; classes/methods PascalCase; locals/params camelCase; async methods end with `Async`. Organize code by feature (folders: `Controllers/`, `Services/`, `Models/`).
-- TypeScript/Angular (UI): 2‑space indent, single quotes, ESLint + Prettier. File names kebab‑case (e.g., `user-profile.component.ts`). Run `npm run lint` and `npm run format`.
+- C# (API): 4-space indentation; classes/methods PascalCase; locals/params camelCase; async methods end with `Async`. Keep feature logic co-located (controllers, services, validators, DTOs) and route shared middleware/extensions/constants to their dedicated folders.
+- TypeScript/Angular (UI): 2-space indent, single quotes, ESLint + Prettier enforced. Follow feature-based modules within `src/app`, keep filenames kebab-case (e.g., `profile-card.component.ts`), and run `npm run lint` plus `npm run format` before committing.
 
 ## Testing Guidelines
-- API: xUnit in `AI.ProfilePhotoMaker.API.Tests/*`; arrange by feature; run with `dotnet test`.
-- UI: small units with Karma/Jasmine (`npm test`); flows with Playwright (`npm run test:e2e`). Place spec files alongside code or in established `tests/` folders.
-- Integration: use `./dev-test.sh` and root tests. Keep tests deterministic and idempotent.
+- API: `AI.ProfilePhotoMaker.API.Tests` hosts unit, integration, controller, service, infrastructure, and performance suites. `dotnet test` exercises them; integration tests expect the SQL Server from `./dev-start.sh`.
+- UI: Component and unit coverage via Karma (`npm test`), with extended scenarios in `npm run test:integration`. Playwright (`npm run test:e2e`) verifies UI flows; headless/targeted variants exist for CI and debugging.
+- Cross-cutting E2E: Repository-level Playwright specs reside in `tests/e2e`, while API release readiness checks run from `AI.ProfilePhotoMaker.API/tests/playwright`. Keep all E2E tests deterministic and idempotent.
 
 ## Commit & Pull Request Guidelines
-- Never create Pull Request without confirming
-- Conventional Commits (examples): `feat(ui): add cropping tool`, `fix(api): null check in upload`.
-- PRs: include summary, linked issues, and test evidence (logs/screenshots for UI). Ensure `npm run lint` (UI), `dotnet build` and `dotnet test` (API), and relevant Playwright tests pass.
+- Keep `main` stable—never open a PR without confirming with the team.
+- Use Conventional Commits (e.g., `feat(ui): add cropping tool`, `fix(api): null check in upload`).
+- PRs need a summary, linked issues, and test evidence (logs/screenshots for UI). Validate `npm run lint`, `npm run test`/`npm run test:e2e` as applicable, along with `dotnet build`, `dotnet test`, and API Playwright final validations when changing release-critical paths.
 
 ## Security & Configuration Tips
-- Never commit secrets. Use `.env.example` as reference; prefer environment variables or `dotnet user-secrets` for local secrets.
-- Sensitive values (e.g., `REPLICATE_API_TOKEN`, Azure Storage) must come from env/secrets. If changing ports, update `proxy.conf.json`, `docker-compose.yml`, and scripts.
-
+- Never commit secrets—follow `.env.example` and prefer environment variables or `dotnet user-secrets` locally.
+- Sensitive values (e.g., `REPLICATE_API_TOKEN`, Azure Storage) must stay in env/secrets. If adjusting ports or hosts, update `proxy.conf*.json`, `docker-compose.yml`, relevant scripts, and Playwright configs under `tests/`.
+- Consult `AI.ProfilePhotoMaker.API/SECURITY_NOTES.md` and `AI.ProfilePhotoMaker.API/MONITORING_SYSTEM_SUMMARY.md` when modifying auth, monitoring, or webhook integrations.

--- a/AI.ProfilePhotoMaker.API/Configuration/LegacyCompatibilityOptions.cs
+++ b/AI.ProfilePhotoMaker.API/Configuration/LegacyCompatibilityOptions.cs
@@ -1,0 +1,25 @@
+namespace AI.ProfilePhotoMaker.API.Configuration;
+
+/// <summary>
+/// Centralized switches for legacy fallback behavior so we can phase out
+/// compatibility paths safely while gathering telemetry.
+/// </summary>
+public class LegacyCompatibilityOptions
+{
+    public const string SectionName = "LegacyCompatibility";
+
+    /// <summary>
+    /// Allow WebhookUrlResolver to fall back to AppBaseUrl when ExternalApiBaseUrl is missing.
+    /// </summary>
+    public bool EnableWebhookAppBaseFallback { get; set; } = true;
+
+    /// <summary>
+    /// Permit AuthService to read legacy JWT configuration keys ("JWT:") if new casing not present.
+    /// </summary>
+    public bool EnableAuthLegacyJwtKeyFallback { get; set; } = true;
+
+    /// <summary>
+    /// Enable the retention job to scan legacy enhanced/ paths without environment prefixes.
+    /// </summary>
+    public bool EnableLegacyEnhancedPathLookup { get; set; } = true;
+}

--- a/AI.ProfilePhotoMaker.API/Program.cs
+++ b/AI.ProfilePhotoMaker.API/Program.cs
@@ -134,6 +134,7 @@ builder.Services.AddSession(options =>
 
 // Add environment configuration with validation
 builder.Services.AddEnvironmentConfiguration();
+builder.Services.Configure<LegacyCompatibilityOptions>(builder.Configuration.GetSection(LegacyCompatibilityOptions.SectionName));
 
 // Configure database services
 if (builder.Environment.IsEnvironment("Testing"))

--- a/AI.ProfilePhotoMaker.API/Services/Authentication/AuthService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/Authentication/AuthService.cs
@@ -1,6 +1,7 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using AI.ProfilePhotoMaker.API.Configuration;
 using AI.ProfilePhotoMaker.API.Data;
 using AI.ProfilePhotoMaker.API.Models;
 using AI.ProfilePhotoMaker.API.Models.DTOs;
@@ -8,6 +9,8 @@ using AI.ProfilePhotoMaker.API.Services.Authentication.interfaces;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 
 namespace AI.ProfilePhotoMaker.API.Services.Authentication;
@@ -18,17 +21,23 @@ public class AuthService : IAuthService
     private readonly SignInManager<ApplicationUser> _signInManager;
     private readonly IConfiguration _configuration;
     private readonly ApplicationDbContext _context;
+    private readonly ILogger<AuthService> _logger;
+    private readonly LegacyCompatibilityOptions _legacyOptions;
 
     public AuthService(
         UserManager<ApplicationUser> userManager,
         SignInManager<ApplicationUser> signInManager,
         IConfiguration configuration,
-        ApplicationDbContext context)
+        ApplicationDbContext context,
+        ILogger<AuthService> logger,
+        IOptions<LegacyCompatibilityOptions> legacyOptions)
     {
         _userManager = userManager;
         _signInManager = signInManager;
         _configuration = configuration;
         _context = context;
+        _logger = logger;
+        _legacyOptions = legacyOptions.Value;
     }
 
     public async Task<AuthResponseDto> RegisterAsync(RegisterDto model)
@@ -112,10 +121,20 @@ public class AuthService : IAuthService
             };
 
             // Read JWT configuration using the same key casing used by validation ("Jwt")
-            // Fall back to legacy "JWT" keys if present for robustness
-            string? secret = _configuration["Jwt:Secret"] ?? _configuration["JWT:Secret"];
+            var secret = _configuration["Jwt:Secret"];
+            if (string.IsNullOrWhiteSpace(secret) && _legacyOptions.EnableAuthLegacyJwtKeyFallback)
+            {
+                secret = _configuration["JWT:Secret"];
+                if (!string.IsNullOrWhiteSpace(secret))
+                {
+                    _logger.LogWarning(
+                        "Using legacy JWT secret configuration key \"JWT:Secret\". Migrate to \"Jwt:Secret\" and disable LegacyCompatibility.EnableAuthLegacyJwtKeyFallback when ready.");
+                }
+            }
+
             if (string.IsNullOrWhiteSpace(secret))
             {
+                _logger.LogError("Missing JWT Secret in configuration (Jwt:Secret) and legacy fallback disabled or unavailable.");
                 throw new InvalidOperationException("Missing JWT Secret in configuration (Jwt:Secret)");
             }
 
@@ -124,8 +143,28 @@ public class AuthService : IAuthService
             var expires = DateTime.UtcNow.AddHours(1);
 
             // Ensure issuer/audience match the casing used by JwtBearer validation (Program.cs uses "Jwt")
-            var issuer = _configuration["Jwt:ValidIssuer"] ?? _configuration["JWT:ValidIssuer"];
-            var audience = _configuration["Jwt:ValidAudience"] ?? _configuration["JWT:ValidAudience"];
+            var issuer = _configuration["Jwt:ValidIssuer"];
+            var audience = _configuration["Jwt:ValidAudience"];
+
+            if (string.IsNullOrWhiteSpace(issuer) && _legacyOptions.EnableAuthLegacyJwtKeyFallback)
+            {
+                issuer = _configuration["JWT:ValidIssuer"];
+                if (!string.IsNullOrWhiteSpace(issuer))
+                {
+                    _logger.LogWarning(
+                        "Using legacy JWT issuer configuration key \"JWT:ValidIssuer\". Update to \"Jwt:ValidIssuer\" once environments are migrated.");
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(audience) && _legacyOptions.EnableAuthLegacyJwtKeyFallback)
+            {
+                audience = _configuration["JWT:ValidAudience"];
+                if (!string.IsNullOrWhiteSpace(audience))
+                {
+                    _logger.LogWarning(
+                        "Using legacy JWT audience configuration key \"JWT:ValidAudience\". Update to \"Jwt:ValidAudience\" once environments are migrated.");
+                }
+            }
 
             var token = new JwtSecurityToken(
                 issuer: issuer,

--- a/AI.ProfilePhotoMaker.API/Services/RetentionPolicyService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/RetentionPolicyService.cs
@@ -1,7 +1,9 @@
+using AI.ProfilePhotoMaker.API.Configuration;
 using AI.ProfilePhotoMaker.API.Data;
 using AI.ProfilePhotoMaker.API.Models;
 using AI.ProfilePhotoMaker.API.Services.Storage;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace AI.ProfilePhotoMaker.API.Services;
 
@@ -11,17 +13,20 @@ public class RetentionPolicyService : IRetentionPolicyService
     private readonly IStorageService _storageService;
     private readonly StoragePathResolver _pathResolver;
     private readonly ILogger<RetentionPolicyService> _logger;
+    private readonly LegacyCompatibilityOptions _legacyOptions;
 
     public RetentionPolicyService(
         ApplicationDbContext context,
         IStorageService storageService,
         StoragePathResolver pathResolver,
-        ILogger<RetentionPolicyService> logger)
+        ILogger<RetentionPolicyService> logger,
+        IOptions<LegacyCompatibilityOptions> legacyOptions)
     {
         _context = context;
         _storageService = storageService;
         _pathResolver = pathResolver;
         _logger = logger;
+        _legacyOptions = legacyOptions.Value;
     }
 
     public async Task<int> DeleteExpiredImagesAsync()
@@ -252,7 +257,18 @@ public class RetentionPolicyService : IRetentionPolicyService
             var enhancedFiles = await _storageService.ListFilesAsync(enhancedPrefix);
             
             // Also check for legacy enhanced files without environment prefix (for backward compatibility)
-            var legacyEnhancedFiles = await _storageService.ListFilesAsync("enhanced/");
+            List<string> legacyEnhancedFiles;
+            if (_legacyOptions.EnableLegacyEnhancedPathLookup)
+            {
+                legacyEnhancedFiles = await _storageService.ListFilesAsync("enhanced/");
+            }
+            else
+            {
+                legacyEnhancedFiles = new List<string>();
+                _logger.LogDebug(
+                    "Skipping legacy enhanced path lookup because LegacyCompatibility.EnableLegacyEnhancedPathLookup is disabled."
+                );
+            }
             
             // Combine both lists and remove duplicates
             var allEnhancedFiles = enhancedFiles.Concat(legacyEnhancedFiles).Distinct().ToList();
@@ -263,8 +279,16 @@ public class RetentionPolicyService : IRetentionPolicyService
                 return 0;
             }
             
-            _logger.LogInformation("Found {PrefixedCount} enhanced files in prefixed path and {LegacyCount} in legacy path for cleanup", 
-                enhancedFiles.Count, legacyEnhancedFiles.Count);
+            if (_legacyOptions.EnableLegacyEnhancedPathLookup)
+            {
+                _logger.LogInformation("Found {PrefixedCount} enhanced files in prefixed path and {LegacyCount} in legacy path for cleanup", 
+                    enhancedFiles.Count, legacyEnhancedFiles.Count);
+            }
+            else
+            {
+                _logger.LogInformation("Found {PrefixedCount} enhanced files in prefixed path; legacy path lookup disabled via configuration", 
+                    enhancedFiles.Count);
+            }
 
             // Build a set of enhanced file paths that are referenced in the database
             var referencedEnhancedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -272,12 +296,15 @@ public class RetentionPolicyService : IRetentionPolicyService
             {
                 var envPrefix = _pathResolver.GetDirectoryPrefix(StorageType.Enhanced);
                 var legacyPrefix = "enhanced/";
+                var allowLegacyInDbScan = _legacyOptions.EnableLegacyEnhancedPathLookup;
 
                 var dbReferenced = await _context.ProcessedImages
                     .Where(pi => (!string.IsNullOrEmpty(pi.ProcessedImageUrl) &&
-                                  (pi.ProcessedImageUrl.StartsWith(envPrefix) || pi.ProcessedImageUrl.StartsWith(legacyPrefix))) ||
+                                  (pi.ProcessedImageUrl.StartsWith(envPrefix) ||
+                                   (allowLegacyInDbScan && pi.ProcessedImageUrl.StartsWith(legacyPrefix)))) ||
                                   (!string.IsNullOrEmpty(pi.OriginalImageUrl) &&
-                                  (pi.OriginalImageUrl.StartsWith(envPrefix) || pi.OriginalImageUrl.StartsWith(legacyPrefix))))
+                                   (pi.OriginalImageUrl.StartsWith(envPrefix) ||
+                                    (allowLegacyInDbScan && pi.OriginalImageUrl.StartsWith(legacyPrefix)))))
                     .Select(pi => new { pi.ProcessedImageUrl, pi.OriginalImageUrl })
                     .ToListAsync();
 

--- a/AI.ProfilePhotoMaker.API/Services/WebhookUrlResolver.cs
+++ b/AI.ProfilePhotoMaker.API/Services/WebhookUrlResolver.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using AI.ProfilePhotoMaker.API.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace AI.ProfilePhotoMaker.API.Services;
 
@@ -11,6 +13,7 @@ public class WebhookUrlResolver : IWebhookUrlResolver
     private readonly IWebHostEnvironment _environment;
     private readonly ILogger<WebhookUrlResolver> _logger;
     private readonly HttpClient _httpClient;
+    private readonly LegacyCompatibilityOptions _legacyOptions;
 
     // Cache resolved URL to avoid repeated lookups
     private string? _cachedWebhookBaseUrl;
@@ -21,12 +24,14 @@ public class WebhookUrlResolver : IWebhookUrlResolver
         IConfiguration configuration,
         IWebHostEnvironment environment,
         ILogger<WebhookUrlResolver> logger,
-        HttpClient httpClient)
+        HttpClient httpClient,
+        IOptions<LegacyCompatibilityOptions> legacyOptions)
     {
         _configuration = configuration;
         _environment = environment;
         _logger = logger;
         _httpClient = httpClient;
+        _legacyOptions = legacyOptions.Value;
     }
 
     public async Task<string?> GetWebhookBaseUrlAsync()
@@ -167,6 +172,13 @@ public class WebhookUrlResolver : IWebhookUrlResolver
             return apiBaseUrl.TrimEnd('/');
         }
 
+        if (!_legacyOptions.EnableWebhookAppBaseFallback)
+        {
+            _logger.LogError(
+                "ExternalApiBaseUrl missing and legacy AppBaseUrl fallback disabled via configuration. Webhooks will remain disabled until ExternalApiBaseUrl is set.");
+            return null;
+        }
+
         // Fallback to AppBaseUrl only if API base URL is not configured (legacy)
         var appBaseUrl = _configuration["AppBaseUrl"];
         if (string.IsNullOrWhiteSpace(appBaseUrl))
@@ -175,7 +187,9 @@ public class WebhookUrlResolver : IWebhookUrlResolver
             return null;
         }
 
-        _logger.LogWarning("Falling back to AppBaseUrl for webhook base in production. Consider setting ExternalApiBaseUrl to the API domain.");
+        _logger.LogWarning(
+            "Using legacy AppBaseUrl fallback for webhooks in production: {AppBaseUrl}. Configure ExternalApiBaseUrl or disable LegacyCompatibility.EnableWebhookAppBaseFallback to prevent this path.",
+            appBaseUrl);
         return appBaseUrl.TrimEnd('/');
     }
 

--- a/AI.ProfilePhotoMaker.API/appsettings.Development.json
+++ b/AI.ProfilePhotoMaker.API/appsettings.Development.json
@@ -53,6 +53,11 @@
       "AI.ProfilePhotoMaker.API.Middleware.StorageProxyMiddleware": "Debug"
     }
   },
+  "LegacyCompatibility": {
+    "EnableWebhookAppBaseFallback": true,
+    "EnableAuthLegacyJwtKeyFallback": true,
+    "EnableLegacyEnhancedPathLookup": true
+  },
   "AllowedHosts": "*"
   ,
   "Storage": {

--- a/AI.ProfilePhotoMaker.API/appsettings.Development.json.template
+++ b/AI.ProfilePhotoMaker.API/appsettings.Development.json.template
@@ -21,5 +21,10 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "LegacyCompatibility": {
+    "EnableWebhookAppBaseFallback": true,
+    "EnableAuthLegacyJwtKeyFallback": true,
+    "EnableLegacyEnhancedPathLookup": true
   }
 }

--- a/AI.ProfilePhotoMaker.API/appsettings.json
+++ b/AI.ProfilePhotoMaker.API/appsettings.json
@@ -55,6 +55,11 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "LegacyCompatibility": {
+    "EnableWebhookAppBaseFallback": true,
+    "EnableAuthLegacyJwtKeyFallback": true,
+    "EnableLegacyEnhancedPathLookup": true
+  },
   "AllowedHosts": "*"
   ,
   "Storage": {

--- a/AI.ProfilePhotoMaker.UI/src/app/services/model-status-mapper.service.ts
+++ b/AI.ProfilePhotoMaker.UI/src/app/services/model-status-mapper.service.ts
@@ -12,6 +12,7 @@ import {
 } from '../models/model-status.types';
 import { UnifiedModelStatusCode, UnifiedModelStatusResponse } from './file-upload.service';
 import { ModelCreationStatus } from '../models/database.types';
+import { LoggingService } from './logging.service';
 
 /**
  * Service responsible for mapping between different status representations
@@ -24,6 +25,21 @@ import { ModelCreationStatus } from '../models/database.types';
   providedIn: 'root',
 })
 export class ModelStatusMapperService {
+  private legacyUsageLogged = false;
+
+  constructor(private readonly loggingService: LoggingService) {}
+
+  private logLegacyUsage(origin: string, metadata?: Record<string, unknown>): void {
+    const payload = metadata ? { origin, ...metadata } : { origin };
+
+    if (!this.legacyUsageLogged) {
+      this.loggingService.warn('Legacy model status bridge invoked', payload);
+      this.legacyUsageLogged = true;
+    } else {
+      this.loggingService.debug(`Legacy model status bridge invoked via ${origin}`, payload);
+    }
+  }
+
   /**
    * Create ModelStatus from API response (primary method)
    */
@@ -86,6 +102,12 @@ export class ModelStatusMapperService {
     progress?: number,
     error?: string
   ): ModelStatus {
+    this.logLegacyUsage('fromLegacyStatus', {
+      legacyStatus,
+      uploadedImages,
+      hasTrainedModel,
+    });
+
     const state = this.mapLegacyStringToState(legacyStatus);
 
     return {
@@ -109,6 +131,13 @@ export class ModelStatusMapperService {
    * Create adapter for gradual migration (supports both old and new)
    */
   createAdapter(status: ModelStatus): ModelStatusAdapter {
+    if (status.metadata?.legacyStatus) {
+      this.logLegacyUsage('createAdapter', {
+        legacyStatus: status.metadata.legacyStatus,
+        source: status.metadata.source,
+      });
+    }
+
     return {
       status,
       legacyStatus: status.metadata.legacyStatus || this.mapStateToLegacyString(status.state),

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -7,6 +7,26 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 START_API=true
 START_UI=true
+API_STARTED=false
+UI_STARTED=false
+NGROK_PID=""
+
+cleanup() {
+  local exit_code=$?
+  if [[ $exit_code -ne 0 ]]; then
+    echo "❌ dev-start encountered an error. Cleaning up partial state..." >&2
+    if [[ -n ${NGROK_PID:-} ]] && kill -0 "$NGROK_PID" >/dev/null 2>&1; then
+      kill "$NGROK_PID" 2>/dev/null || true
+    fi
+    if [[ $UI_STARTED == true ]]; then
+      bash "$SCRIPT_DIR/scripts/ui-stop.sh" >/dev/null 2>&1 || true
+    fi
+    if [[ $API_STARTED == true ]]; then
+      bash "$SCRIPT_DIR/scripts/api-stop.sh" >/dev/null 2>&1 || true
+    fi
+  fi
+}
+trap cleanup EXIT
 
 for arg in "$@"; do
   case "$arg" in
@@ -18,15 +38,24 @@ done
 if $START_API; then
   echo "➡️  Starting API (dev)"
   bash "$SCRIPT_DIR/scripts/api-start.sh"
+  API_STARTED=true
 fi
 
 if $START_UI; then
   echo "➡️  Starting UI (dev)"
   bash "$SCRIPT_DIR/scripts/ui-start.sh"
+  UI_STARTED=true
 fi
 
-echo "➡️  Starting ngrok tunnel"
-ngrok http 5032 --domain clear-anteater-usually.ngrok-free.app &
+if command -v ngrok >/dev/null 2>&1; then
+  echo "➡️  Starting ngrok tunnel"
+  ngrok http 5032 --domain clear-anteater-usually.ngrok-free.app >/dev/null 2>&1 &
+  NGROK_PID=$!
+else
+  echo "⚠️  ngrok not found on PATH; skipping tunnel startup"
+fi
+
+trap - EXIT
 
 echo "✅ Dev services started (API/UI)."
 

--- a/docs/refactor/cleanup-checklist.md
+++ b/docs/refactor/cleanup-checklist.md
@@ -1,0 +1,99 @@
+# Cleanup & Refactor Readiness Checklist
+
+## Approach & Safety Principles
+- Inventory only: this document captures investigation targets before touching code.
+- Sequence work by risk: start with isolated folders/files, end with cross-cutting runtime paths.
+- Require green automation before and after any change: `dotnet build`, `dotnet test`, `npm run lint`, `npm test`, `npm run test:e2e`, and relevant Playwright suites.
+- Snapshot telemetry: gather baseline metrics/logging so we can detect regressions after cleanup.
+
+## Global Verification Prerequisites
+1. Run `./dev-start.sh` to ensure local stack is healthy before removing anything.
+2. Capture API smoke results via `dotnet test AI.ProfilePhotoMaker.API.Tests`.
+3. Capture UI smoke via `npm run quality:check` and `npm run test:e2e` (after `npm run playwright:install`).
+4. Document environment settings used for validation (notably storage, webhook tunnels, feature flags).
+5. For any item touching deployment/self-hosted scripts, dry-run `./scripts/validate-*.sh` helpers.
+
+## Priority: High (Quick Wins / Low Risk)
+- [ ] **Evaluate empty legacy project folder** *(API)*  
+  - Location: `AI.ProfilePhotoMaker.API/AI.ProfilePhotoMaker.API` (currently only `obj/`).  
+  - Rationale: Vestigial directory increases confusion during onboarding.  
+  - Action: Confirm `.csproj` and solution references do not rely on this folder, then remove or document necessity.  
+  - Validation: `dotnet build AI.ProfilePhotoMaker.sln` and smoke run of API.
+- [ ] **Retire deprecated style preview URL helper** *(UI)*  
+  - Location: `AI.ProfilePhotoMaker.UI/src/app/services/config.service.ts:252-260`.  
+  - Rationale: Method returns placeholder URL and is superseded by `StylePreviewService`.  
+  - Action: Verify no templates/tests call `buildStylePreviewUrl`, remove helper, update docs.  
+  - Validation: `npm test`, `npm run test:e2e` focusing on style previews.
+- [ ] **Decommission dormant Cypress suite** *(UI tooling)*  
+  - Location: `AI.ProfilePhotoMaker.UI/cypress/e2e/file-upload-icon-positioning.cy.ts`.  
+  - Rationale: Playwright replaced Cypress; retaining folder adds maintenance overhead.  
+  - Action: Confirm CI/docs do not reference Cypress, archive any findings, delete folder.  
+  - Validation: Search `.github/` workflows and `package.json` to ensure no Cypress calls remain.
+- [ ] **Clean empty Angular scaffolding directories** *(UI)*  
+  - Locations: `AI.ProfilePhotoMaker.UI/tests/`, `AI.ProfilePhotoMaker.UI/e2e/` (empty).  
+  - Rationale: Reduces clutter and confusion for new contributors.  
+  - Action: Ensure Angular CLI schematics do not target these paths; remove or add README if required.  
+  - Validation: `npm run lint` and `ng generate component` smoke test.
+- [ ] **Confirm empty `tools/` directory necessity** *(Repo root)*  
+  - Location: `tools/` (empty).  
+  - Rationale: Clarify whether this is intentional placeholder.  
+  - Action: Add README explaining purpose or remove the directory.  
+  - Validation: None—documentation update only.
+
+## Priority: Medium (Coordinated Cleanups)
+- [ ] **Review console logging left in production services** *(UI)*  
+  - Examples: `AI.ProfilePhotoMaker.UI/src/app/services/file-upload.service.ts:445-509`, `.../services/workflow-orchestration.service.ts:384-845`, `.../pages/premium/premium.component.ts:162-185`.  
+  - Rationale: Verbose logs can leak sensitive data and clutter prod consoles.  
+  - Action: Route critical diagnostics through `LoggingService`; guard or remove noisy logs.  
+  - Validation: Manual QA around uploads, workflow routing, premium purchase flows.
+- [ ] **Prune test artifacts and empty result folders** *(Tests)*  
+  - Location: `AI.ProfilePhotoMaker.API/tests/playwright/tests/test-results/` (empty).  
+  - Rationale: Avoid tracking empty directories unless required by CI.  
+  - Action: Remove if unnecessary; rely on runtime creation.  
+  - Validation: `npx playwright test` to confirm reports still emit.
+- [ ] **Remove unused Claude docs stub** *(UI docs)*  
+  - Location: `AI.ProfilePhotoMaker.UI/ClaudeDocs/Report/` (empty).  
+  - Rationale: Abandoned artifact increases repository noise.  
+  - Action: Confirm with doc owners, delete or repurpose directory, update indices.  
+  - Validation: Ensure `docs/claudedocs-index.md` does not reference the path.
+- [ ] **Confirm social login TODOs should stay visible** *(UI auth)*  
+  - Locations: `AI.ProfilePhotoMaker.UI/src/app/auth/login/login.component.ts:211-216`, `.../register/register.component.ts:135-140`.  
+  - Rationale: Persistent TODOs indicate roadmap uncertainty.  
+  - Action: Sync with product roadmap; either convert to tracked issues or keep TODOs intentionally.  
+  - Validation: None—communication/documentation task.
+- [ ] **Finish rollback logic for unified secrets deployment** *(Scripts)*  
+  - Location: `scripts/deploy-with-unified-secrets.sh:179`.  
+  - Rationale: TODO placeholder leaves rollout without safe fallback.  
+  - Action: Design rollback flow or document manual steps; test via dry-run.  
+  - Validation: Execute script in staging; verify failure paths restore prior state.
+- [ ] **Review shell duplicates for API/UI control** *(Scripts)*  
+  - Locations: `scripts/api-start.sh`, `scripts/api-start.ps1`, matching stop/restart scripts.  
+  - Rationale: Maintaining Bash and PowerShell variants may be unnecessary.  
+  - Action: Survey developer usage; if PowerShell variants unused, plan deprecation and update onboarding docs.  
+  - Validation: Confirm Windows contributors have alternative workflow before removal.
+
+## Priority: Low / Strategic (High Coordination or Long Tail)
+- [ ] **Deprecate legacy webhook/auth fallbacks once config parity confirmed** *(API)*  
+  - Locations: `AI.ProfilePhotoMaker.API/Services/WebhookUrlResolver.cs:170`, `.../Services/Authentication/AuthService.cs:115`.  
+  - Rationale: Backward-compatibility paths complicate config management.  
+  - Action: Audit active environments; if legacy keys unused, remove behind feature flag or telemetry toggle.  
+  - Validation: Exercise OAuth/webhook flows via ngrok per `docs/webhooks/INTEGRATION.md`.  
+  - Status: `LegacyCompatibilityOptions` now gate fallbacks with structured logging (Jan 2025).
+- [ ] **Assess retention of legacy enhanced file paths** *(API storage)*  
+  - Location: `AI.ProfilePhotoMaker.API/Services/RetentionPolicyService.cs:254-280`.  
+  - Rationale: Cleanup job maintains both prefixed and legacy paths; removal reduces complexity.  
+  - Action: Confirm storage no longer writes legacy paths; migrate job to single path.  
+  - Validation: Run retention policy integration tests and storage cleanup scripts in staging.  
+  - Status: Legacy scan wrapped in `LegacyCompatibilityOptions.EnableLegacyEnhancedPathLookup`; logging added when disabled (Jan 2025).
+- [ ] **Audit legacy status bridging layer** *(UI model status)*  
+  - Locations: `AI.ProfilePhotoMaker.UI/src/app/models/dashboard.types.ts:73-161`, `.../services/model-status-mapper.service.ts:41-360`, `.../services/model-state.service.ts:234-256`.  
+  - Rationale: Extensive conversion logic keeps `legacyStatus` strings alive; cleanup requires API alignment.  
+  - Action: Coordinate with API team, gather telemetry on `legacyStatus` usage, plan phased removal.  
+  - Validation: Instrument UI logs/metrics before deleting pathways.  
+  - Status: Mapper emits a one-time warning + debug traces when legacy adapters run (Jan 2025).
+- [ ] **Deduplicate Playwright suites** *(Cross-stack testing)*  
+  - Locations: `tests/e2e/` vs `AI.ProfilePhotoMaker.API/tests/playwright/`.  
+  - Rationale: Dual suites risk drift; consolidation could reduce maintenance.  
+  - Action: Chart coverage per suite, evaluate shared configs or consolidation.  
+  - Validation: Run both suites post-change; ensure Azure credential-dependent tests remain isolated.  
+  - Status: Coverage and dependency summary captured in `docs/refactor/playwright-suite-overview.md` (Jan 2025).

--- a/docs/refactor/playwright-suite-overview.md
+++ b/docs/refactor/playwright-suite-overview.md
@@ -1,0 +1,32 @@
+# Playwright Suite Overlap Assessment
+
+## Repository-Level Suite (`tests/e2e`)
+- Entry point: `tests/e2e/image-upload-validation.spec.js` with shared config `tests/e2e/playwright.config.js`.
+- Focus: Production/staging smoke for image upload validation across desktop, cross-browser, and mobile devices.
+- Execution model: Sequential (fullyParallel=false) with retries in CI, optional local `webServer` spin-up when `START_LOCAL_SERVER` set.
+- Reporting: HTML + JSON outputs in `test-results/`, GitHub reporter enabled on CI.
+- Dependencies: Reads `TEST_BASE_URL`, `STAGING_URL` env vars; no storage credentials required (validates response codes and basic flows).
+
+## API Release Suite (`AI.ProfilePhotoMaker.API/tests/playwright`)
+- Entry point: `AI.ProfilePhotoMaker.API/tests/playwright/tests/*` with configuration in `playwright.config.ts`.
+- Coverage highlights:
+  - Style preview lifecycle (`01-pre-upload-validation.spec.ts` → `04-style-preview-integration.spec.ts`).
+  - Azure credential validation (`03-credential-validation.spec.ts`, `azure-config.ts`).
+  - OAuth regression coverage (`08-oauth-production-validation.spec.ts`, `09-simple-oauth-check.spec.ts`, `oauth-final-test.spec.ts`).
+  - Retention/cleanup verification for enhanced images (`enhanced-image-deletion-*.spec.ts`).
+  - Training workflow diagnostics (`comprehensive-training-workflow-validation.spec.ts`).
+  - Authenticated API smoke (`authenticated-request-test.spec.ts`, `auth-profile-completion-flow.spec.ts`).
+- Execution profiles: Multiple npm scripts (`test`, `test:headed`, `test:performance`, etc.) with optional Azure credentials to unlock post-upload checks.
+- Reporting: Playwright default output plus curated reports in `tests/test-results/` (HTML/trace retained).
+- Dependencies: Azure Storage SAS/connection string, OAuth secrets, environment-specific URLs (documented in README and `.env.template`).
+
+## Observations
+- Suites target different scopes: root suite validates end-user journey, API suite validates backend release readiness and infrastructure.
+- There is overlap on style preview validation (404 vs 200 checks) but API suite adds credential-dependent coverage.
+- Both suites maintain their own configs/reporting; risk of drift in shared constants (style names, endpoints).
+
+## Proposed Follow-Up (Low Priority Roadmap)
+1. Introduce a shared catalog of style names/endpoints (`tests/shared/style-catalog.ts`) consumed by both suites.
+2. Evaluate merging reporters to a single `test-results` root with sub-folders (`/e2e`, `/api-release`) to simplify artifact collection.
+3. Create matrix documenting which CI jobs run each suite to avoid redundant production hits.
+4. Consider housing API suite within root `tests/` via Playwright projects, while preserving credential-gated scripts.


### PR DESCRIPTION
## Summary
- introduce LegacyCompatibilityOptions toggles and wire them into API services
- add telemetry/logging for legacy status bridge usage in UI
- document Playwright suite split and harden dev-start cleanup

## Testing
- ./dev-rebuild.sh