### PR TITLE
fix(ui): use config urls for oauth helpers

### DIFF
--- a/AI.ProfilePhotoMaker.UI/src/app/app.component.ts
+++ b/AI.ProfilePhotoMaker.UI/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
 import { filter } from 'rxjs/operators';
 import { AuthService } from './services/auth.service';
 import { ThemeService } from './services/theme.service';
+import { ConfigService } from './services/config.service';
 import { NotificationComponent } from './components/shared/notification/notification.component';
 import { environment } from '../environments/environment';
 
@@ -19,6 +20,7 @@ export class AppComponent implements OnInit {
   private readonly _router = inject(Router);
   private readonly _authService = inject(AuthService);
   private readonly _themeService = inject(ThemeService);
+  private readonly _config = inject(ConfigService);
 
   ngOnInit(): void {
     // Initialize theme service to ensure proper theme application
@@ -41,7 +43,9 @@ export class AppComponent implements OnInit {
 
     if (shouldHandleToken) {
       // In development OAuth flow, set cookie via same-origin endpoint then clean URL
-      fetch('/api/auth/set-cookie', {
+      const setCookieUrl = this._config.getFullUrl('/auth/set-cookie');
+
+      fetch(setCookieUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ token }),

--- a/AI.ProfilePhotoMaker.UI/src/app/services/auth.service.ts
+++ b/AI.ProfilePhotoMaker.UI/src/app/services/auth.service.ts
@@ -400,7 +400,8 @@ export class AuthService {
           // In development only, ensure cookie is set via same-origin endpoint (proxy)
           if (!environment.production && response.token) {
             try {
-              await fetch('/api/auth/set-cookie', {
+              const setCookieUrl = this._config.getFullUrl('/auth/set-cookie');
+              await fetch(setCookieUrl, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ token: response.token }),
@@ -432,7 +433,8 @@ export class AuthService {
         switchMap(async response => {
           if (!environment.production && response.token) {
             try {
-              await fetch('/api/auth/set-cookie', {
+              const setCookieUrl = this._config.getFullUrl('/auth/set-cookie');
+              await fetch(setCookieUrl, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ token: response.token }),

--- a/AI.ProfilePhotoMaker.UI/src/app/services/style-preview.service.ts
+++ b/AI.ProfilePhotoMaker.UI/src/app/services/style-preview.service.ts
@@ -178,7 +178,7 @@ export class StylePreviewService {
       return directUrl;
     }
     // Return placeholder image API endpoint as last resort
-    return `/api/placeholder/style-preview`;
+    return this._config.getFullUrl('/placeholder/style-preview');
   }
 
   /**


### PR DESCRIPTION
## Summary
- build the OAuth cookie endpoint via ConfigService so docker builds hit the API host directly
- reuse ConfigService for dev-only cookie setup and style preview fallback URLs

## Testing
- npm run lint
