### PR TITLE
fix: align credit purchase layout at tablet width

### DIFF
--- a/AI.ProfilePhotoMaker.UI/src/app/components/credit-packages/credit-packages.component.sass
+++ b/AI.ProfilePhotoMaker.UI/src/app/components/credit-packages/credit-packages.component.sass
@@ -106,6 +106,9 @@
     max-width: 380px
     width: 100%
 
+    @media (max-width: 960px)
+      max-width: none
+
   .billing-block
     gap: 1.1rem
 

--- a/AI.ProfilePhotoMaker.UI/src/app/components/credit-packages/credit-packages.component.sass
+++ b/AI.ProfilePhotoMaker.UI/src/app/components/credit-packages/credit-packages.component.sass
@@ -45,11 +45,22 @@
   padding: 2rem
   margin-bottom: 3rem
   box-shadow: var(--shadow-sm)
-  
+
+  @media (max-width: 768px)
+    padding: 1.75rem 1.25rem
+
+  @media (max-width: 480px)
+    padding: 1.4rem 1rem
+    border-radius: 12px
+    box-shadow: none
+
   h3
     margin: 0 0 1.5rem 0
     color: var(--text-primary)
     text-align: center
+
+    @media (max-width: 480px)
+      font-size: 1.65rem
   
   &.simulation
     .simulation-payment
@@ -64,6 +75,11 @@
     flex-direction: column
     gap: 0.5rem
     margin-bottom: 1.5rem
+
+    @media (max-width: 480px)
+      padding: 1rem
+      border-radius: 12px
+      background: rgba(32, 42, 58, 0.45)
   
   .summary-row
     display: flex
@@ -85,11 +101,14 @@
   .payment-form
     display: grid
     gap: 1.5rem
-    grid-template-columns: minmax(0, 360px) minmax(0, 1fr)
+    grid-template-columns: 1fr
     align-items: flex-start
 
-    @media (max-width: 960px)
-      grid-template-columns: 1fr
+    @media (max-width: 480px)
+      gap: 1.25rem
+
+    @media (min-width: 1024px)
+      grid-template-columns: minmax(0, 360px) minmax(0, 1fr)
 
   .card-block,
   .billing-block
@@ -102,12 +121,16 @@
     gap: 1rem
     box-shadow: var(--shadow-sm)
 
-  .card-block
-    max-width: 380px
-    width: 100%
+    @media (max-width: 480px)
+      padding: 1.1rem 1.25rem
+      border-radius: 12px
 
-    @media (max-width: 960px)
-      max-width: none
+  .card-block
+    width: 100%
+    max-width: none
+
+    @media (min-width: 1024px)
+      max-width: 380px
 
   .billing-block
     gap: 1.1rem
@@ -245,14 +268,28 @@
     gap: 1rem
     justify-content: center
     margin-top: 1.5rem
-    
+    flex-wrap: wrap
+
+    @media (max-width: 640px)
+      flex-direction: column
+      align-items: stretch
+      gap: 0.75rem
+
     .confirm-btn
       min-width: 160px
       @include shared.btn-primary
-    
+
+      @media (max-width: 640px)
+        min-width: 0
+        width: 100%
+
     .cancel-btn
       min-width: 120px
       @include shared.btn-secondary
+
+      @media (max-width: 640px)
+        min-width: 0
+        width: 100%
 
   .webhook-wait-banner
     margin-top: 1.5rem
@@ -532,17 +569,32 @@
 
 .credit-costs-info
   max-width: 900px
-  margin: 0 auto
+  width: 100%
+  margin: 2.5rem auto 0
   background: rgba(255, 255, 255, 0.05)
   border-radius: 16px
   padding: 2rem
   border: 1px solid rgba(255, 255, 255, 0.12)
   backdrop-filter: blur(10px)
 
+  @media (max-width: 768px)
+    padding: 1.75rem 1.25rem
+    border-radius: 14px
+
+  @media (max-width: 480px)
+    padding: 1.35rem 1rem
+    border-radius: 12px
+    margin-top: 2rem
+    background: rgba(10, 18, 32, 0.7)
+
   h3
     margin: 0 0 1.3rem 0
     font-size: 1.6rem
     color: var(--text-primary)
+    text-align: center
+
+    @media (max-width: 480px)
+      font-size: 1.45rem
 
   .cost-grid
     display: flex
@@ -557,6 +609,16 @@
     border-radius: 12px
     background: rgba(0, 0, 0, 0.08)
     color: var(--text-secondary)
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04)
+
+    @media (max-width: 640px)
+      flex-direction: column
+      align-items: flex-start
+      gap: 0.5rem
+      padding: 1rem
+
+    @media (max-width: 480px)
+      border-radius: 10px
 
     .operation
       font-weight: 600
@@ -570,6 +632,10 @@
       margin-left: auto
       font-size: 0.85rem
       color: var(--text-secondary)
+
+      @media (max-width: 640px)
+        margin-left: 0
+        font-size: 0.82rem
 
 // Dark theme styles using Angular's host-context - increased specificity
 :host-context([data-theme="dark"]) .credit-packages-container
@@ -679,10 +745,13 @@
     background: rgba(255, 255, 255, 0.08) !important
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3) !important
 
-  .retention-policy-info,
-  .credit-costs-info
+  .retention-policy-info
     background: rgba(255, 255, 255, 0.05) !important
     border-color: rgba(255, 255, 255, 0.1) !important
+
+  .credit-costs-info
+    background: rgba(16, 26, 46, 0.85) !important
+    border-color: rgba(82, 208, 255, 0.2) !important
 
   .purchase-btn
     background: linear-gradient(135deg, #6f78ff, #8f9bff) !important


### PR DESCRIPTION
## Summary
- refine the Stripe payment modal for phones (single-column grid, responsive padding, stacked buttons)
- refresh the credit costs card styling so copy and cost rows remain readable on mobile and in dark mode

## Testing
- cd AI.ProfilePhotoMaker.UI && npx playwright test tests/credit-card-mobile-layout.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d72d6a42cc83249083eb6c953a8908
