### PR TITLE
fix: balance mobile payment card padding

### DIFF
--- a/AI.ProfilePhotoMaker.UI/src/app/components/credit-packages/credit-packages.component.sass
+++ b/AI.ProfilePhotoMaker.UI/src/app/components/credit-packages/credit-packages.component.sass
@@ -45,14 +45,22 @@
   padding: 2rem
   margin-bottom: 3rem
   box-shadow: var(--shadow-sm)
+  width: 100%
+
+  @media (max-width: 1024px)
+    margin-left: auto
+    margin-right: auto
+    max-width: 680px
 
   @media (max-width: 768px)
     padding: 1.75rem 1.25rem
+    max-width: 520px
 
   @media (max-width: 480px)
     padding: 1.4rem 1rem
     border-radius: 12px
     box-shadow: none
+    max-width: 100%
 
   h3
     margin: 0 0 1.5rem 0

--- a/AI.ProfilePhotoMaker.UI/src/app/components/credit-packages/credit-packages.component.sass
+++ b/AI.ProfilePhotoMaker.UI/src/app/components/credit-packages/credit-packages.component.sass
@@ -60,7 +60,7 @@
     padding: 1.4rem 1rem
     border-radius: 12px
     box-shadow: none
-    max-width: 100%
+    max-width: calc(100% - 2rem)
 
   h3
     margin: 0 0 1.5rem 0


### PR DESCRIPTION
## Summary
- adjust mobile breakpoint max-width so payment card keeps equal gutters
- ensure credit purchase form no longer hugs right edge on phones

## Testing
- n/a (style-only change)