### PR TITLE
fix: tighten mobile payment spacing

### DIFF
--- a/AI.ProfilePhotoMaker.UI/src/app/components/credit-packages/credit-packages.component.sass
+++ b/AI.ProfilePhotoMaker.UI/src/app/components/credit-packages/credit-packages.component.sass
@@ -10,7 +10,7 @@
     
   // Mobile padding optimization
   @media (max-width: 640px)
-    padding: 1.5rem 1rem
+    padding: 1.25rem 0.75rem
 
 .header
   text-align: center
@@ -57,10 +57,10 @@
     max-width: 520px
 
   @media (max-width: 480px)
-    padding: 1.4rem 1rem
+    padding: 1.1rem 0.75rem
     border-radius: 12px
     box-shadow: none
-    max-width: calc(100% - 2rem)
+    max-width: 100%
 
   h3
     margin: 0 0 1.5rem 0
@@ -111,6 +111,8 @@
     gap: 1.5rem
     grid-template-columns: 1fr
     align-items: flex-start
+    width: 100%
+    min-width: 0
 
     @media (max-width: 480px)
       gap: 1.25rem
@@ -128,6 +130,7 @@
     flex-direction: column
     gap: 1rem
     box-shadow: var(--shadow-sm)
+    min-width: 0
 
     @media (max-width: 480px)
       padding: 1.1rem 1.25rem
@@ -191,6 +194,7 @@
     padding: 1rem 1.25rem
     background: rgba(244, 248, 255, 0.92)
     transition: border-color 0.2s ease, box-shadow 0.2s ease
+    min-width: 0
 
     &.focused
       border-color: rgba(82, 208, 255, 0.85)
@@ -211,6 +215,7 @@
     display: grid
     grid-template-columns: repeat(2, minmax(0, 1fr))
     gap: 1rem
+    min-width: 0
 
     @media (max-width: 768px)
       grid-template-columns: 1fr
@@ -219,6 +224,7 @@
     display: flex
     flex-direction: column
     gap: 0.45rem
+    min-width: 0
 
     span
       font-size: 0.9rem


### PR DESCRIPTION
## Summary
- reduce mobile padding on credit purchase container for consistent gutters
- add min-width safeguards so nested grid sections don\'t overflow on phones

## Testing
- n/a (scss-only change)