### PR TITLE
feat: marketing email campaign service

### DIFF
--- a/.github/workflows/pr-code-review.yml
+++ b/.github/workflows/pr-code-review.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
   NODE_VERSION: '20.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true

--- a/.github/workflows/simple-deploy.yml
+++ b/.github/workflows/simple-deploy.yml
@@ -42,8 +42,8 @@ jobs:
       - name: 🏗️ Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
-          
+          dotnet-version: '10.0.x'
+
       - name: 🏗️ Setup Node.js
         uses: actions/setup-node@v5
         with:
@@ -213,7 +213,7 @@ jobs:
       - name: 🏗️ Setup .NET (EF tools)
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
         
       - name: 🔧 Install Azure CLI
         run: |

--- a/AI.ProfilePhotoMaker.API.Tests/Integration/AbandonedUploadBackgroundServiceTests.cs
+++ b/AI.ProfilePhotoMaker.API.Tests/Integration/AbandonedUploadBackgroundServiceTests.cs
@@ -470,6 +470,9 @@ public class AbandonedUploadBackgroundServiceTests
             NudgeCalls.Add(new NudgeCall(userId, email, firstName));
             return Task.CompletedTask;
         }
+
+        public Task<bool> SendMarketingEmailAsync(string userId, string email, string subject, string htmlBody, string unsubscribeUrl) => Task.FromResult(true);
+        public string RenderMarketingEmailPreview(string subject, string htmlBody) => htmlBody;
     }
 
     private sealed record NudgeCall(string UserId, string? Email, string? FirstName);

--- a/AI.ProfilePhotoMaker.API.Tests/Integration/CustomWebApplicationFactory.cs
+++ b/AI.ProfilePhotoMaker.API.Tests/Integration/CustomWebApplicationFactory.cs
@@ -308,6 +308,8 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
         public Task SendWelcomeAsync(string userId, string? email, string? firstName = null) => Task.CompletedTask;
         public Task SendRetentionDeletionWarningAsync(string userId, string? email, int imageCount, DateTime deletionDate, int daysUntilDeletion) => Task.CompletedTask;
         public Task SendAbandonedUploadNudgeAsync(string userId, string? email, string? firstName = null) => Task.CompletedTask;
+        public Task<bool> SendMarketingEmailAsync(string userId, string email, string subject, string htmlBody, string unsubscribeUrl) => Task.FromResult(true);
+        public string RenderMarketingEmailPreview(string subject, string htmlBody) => htmlBody;
     }
 
     private sealed class FakeStorageService : IStorageService

--- a/AI.ProfilePhotoMaker.API.Tests/Integration/RetentionPolicyBackgroundServiceTests.cs
+++ b/AI.ProfilePhotoMaker.API.Tests/Integration/RetentionPolicyBackgroundServiceTests.cs
@@ -490,6 +490,8 @@ public class RetentionPolicyBackgroundServiceTests
         }
 
         public Task SendAbandonedUploadNudgeAsync(string userId, string? email, string? firstName = null) => Task.CompletedTask;
+        public Task<bool> SendMarketingEmailAsync(string userId, string email, string subject, string htmlBody, string unsubscribeUrl) => Task.FromResult(true);
+        public string RenderMarketingEmailPreview(string subject, string htmlBody) => htmlBody;
     }
 
     private sealed record RetentionWarningCall(

--- a/AI.ProfilePhotoMaker.API.Tests/Services/StripeWebhookServiceTests.cs
+++ b/AI.ProfilePhotoMaker.API.Tests/Services/StripeWebhookServiceTests.cs
@@ -528,6 +528,8 @@ public class StripeWebhookServiceTests
         public Task SendWelcomeAsync(string userId, string? email, string? firstName = null) => Task.CompletedTask;
         public Task SendRetentionDeletionWarningAsync(string userId, string? email, int imageCount, DateTime deletionDate, int daysUntilDeletion) => Task.CompletedTask;
         public Task SendAbandonedUploadNudgeAsync(string userId, string? email, string? firstName = null) => Task.CompletedTask;
+        public Task<bool> SendMarketingEmailAsync(string userId, string email, string subject, string htmlBody, string unsubscribeUrl) => Task.FromResult(true);
+        public string RenderMarketingEmailPreview(string subject, string htmlBody) => htmlBody;
     }
 
     private sealed class DummyCouponService : ICouponService

--- a/AI.ProfilePhotoMaker.API/Configuration/EmailOptions.cs
+++ b/AI.ProfilePhotoMaker.API/Configuration/EmailOptions.cs
@@ -49,4 +49,10 @@ public class EmailOptions
     public string? SupportToEmail { get; set; }
 
     public string? SupportToName { get; set; }
+
+    /// <summary>
+    /// Shared secret sent by Postmark in the Authorization header for webhook callbacks.
+    /// Configure Postmark to send: Authorization: Bearer {value}
+    /// </summary>
+    public string? PostmarkWebhookSecret { get; set; }
 }

--- a/AI.ProfilePhotoMaker.API/Configuration/MarketingEmailOptions.cs
+++ b/AI.ProfilePhotoMaker.API/Configuration/MarketingEmailOptions.cs
@@ -1,0 +1,17 @@
+namespace AI.ProfilePhotoMaker.API.Configuration;
+
+public class MarketingEmailOptions
+{
+    public const string SectionName = "MarketingEmail";
+
+    public bool Enabled { get; set; } = true;
+    public TimeSpan InitialDelay { get; set; } = TimeSpan.FromMinutes(2);
+    public TimeSpan CheckInterval { get; set; } = TimeSpan.FromMinutes(1);
+    public TimeSpan ErrorRetryDelay { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>Number of recipients to process per iteration to respect Postmark rate limits.</summary>
+    public int BatchSize { get; set; } = 50;
+
+    /// <summary>Delay between batches in milliseconds.</summary>
+    public int BatchDelayMs { get; set; } = 1000;
+}

--- a/AI.ProfilePhotoMaker.API/Controllers/MarketingCampaignController.cs
+++ b/AI.ProfilePhotoMaker.API/Controllers/MarketingCampaignController.cs
@@ -1,0 +1,195 @@
+using AI.ProfilePhotoMaker.API.Models.DTOs;
+using AI.ProfilePhotoMaker.API.Services.Marketing;
+using AI.ProfilePhotoMaker.API.Services.Notifications;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AI.ProfilePhotoMaker.API.Controllers;
+
+[ApiController]
+[Route("api/admin/campaigns")]
+[Authorize(Roles = "Admin")]
+public class MarketingCampaignController : BaseController
+{
+    private readonly IMarketingEmailService _marketingService;
+    private readonly IUserSegmentService _segmentService;
+    private readonly IEmailNotificationService _emailService;
+
+    public MarketingCampaignController(
+        IMarketingEmailService marketingService,
+        IUserSegmentService segmentService,
+        IEmailNotificationService emailService,
+        ILogger<MarketingCampaignController> logger)
+        : base(logger)
+    {
+        _marketingService = marketingService;
+        _segmentService = segmentService;
+        _emailService = emailService;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateCampaign([FromBody] CreateCampaignRequest request)
+    {
+        var authCheck = ValidateAuthentication();
+        if (authCheck != null) return authCheck;
+
+        return await ExecuteAsync(async () =>
+        {
+            var campaign = await _marketingService.CreateCampaignAsync(request, GetCurrentUserId()!);
+            return CampaignDetailDto.From(campaign);
+        }, "CreateCampaign");
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetCampaigns([FromQuery] int page = 1, [FromQuery] int pageSize = 20)
+    {
+        var authCheck = ValidateAuthentication();
+        if (authCheck != null) return authCheck;
+
+        var (campaigns, total) = await _marketingService.GetCampaignsAsync(page, pageSize);
+        return SuccessResponse(new
+        {
+            campaigns = campaigns.Select(CampaignDto.From),
+            totalCount = total,
+            page,
+            pageSize
+        });
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetCampaign(Guid id)
+    {
+        var authCheck = ValidateAuthentication();
+        if (authCheck != null) return authCheck;
+
+        var campaign = await _marketingService.GetCampaignAsync(id);
+        if (campaign == null) return NotFoundResponse("Campaign", id);
+        return SuccessResponse(CampaignDetailDto.From(campaign));
+    }
+
+    [HttpPatch("{id:guid}")]
+    public async Task<IActionResult> UpdateCampaign(Guid id, [FromBody] UpdateCampaignRequest request)
+    {
+        var authCheck = ValidateAuthentication();
+        if (authCheck != null) return authCheck;
+
+        return await ExecuteAsync(async () =>
+        {
+            var campaign = await _marketingService.UpdateCampaignAsync(id, request);
+            return CampaignDetailDto.From(campaign);
+        }, "UpdateCampaign");
+    }
+
+    [HttpPost("{id:guid}/schedule")]
+    public async Task<IActionResult> ScheduleCampaign(Guid id, [FromBody] ScheduleCampaignRequest request)
+    {
+        var authCheck = ValidateAuthentication();
+        if (authCheck != null) return authCheck;
+
+        return await ExecuteAsync(async () =>
+        {
+            await _marketingService.ScheduleCampaignAsync(id, request.ScheduledAt);
+            return new { scheduled = true };
+        }, "ScheduleCampaign");
+    }
+
+    [HttpPost("{id:guid}/cancel")]
+    public async Task<IActionResult> CancelCampaign(Guid id)
+    {
+        var authCheck = ValidateAuthentication();
+        if (authCheck != null) return authCheck;
+
+        return await ExecuteAsync(async () =>
+        {
+            await _marketingService.CancelCampaignAsync(id);
+            return new { cancelled = true };
+        }, "CancelCampaign");
+    }
+
+    [HttpPost("{id:guid}/test")]
+    public async Task<IActionResult> SendTest(Guid id, [FromBody] SendTestRequest request)
+    {
+        var authCheck = ValidateAuthentication();
+        if (authCheck != null) return authCheck;
+
+        return await ExecuteAsync(async () =>
+        {
+            await _marketingService.SendTestAsync(id, request.TestEmail);
+            return new { sent = true, testEmail = request.TestEmail };
+        }, "SendTest");
+    }
+
+    [HttpPost("{id:guid}/duplicate")]
+    public async Task<IActionResult> DuplicateCampaign(Guid id)
+    {
+        var authCheck = ValidateAuthentication();
+        if (authCheck != null) return authCheck;
+
+        return await ExecuteAsync(async () =>
+        {
+            var copy = await _marketingService.DuplicateCampaignAsync(id, GetCurrentUserId()!);
+            return CampaignDetailDto.From(copy);
+        }, "DuplicateCampaign");
+    }
+
+    [HttpGet("{id:guid}/recipients")]
+    public async Task<IActionResult> GetRecipients(Guid id, [FromQuery] int page = 1, [FromQuery] int pageSize = 50)
+    {
+        var authCheck = ValidateAuthentication();
+        if (authCheck != null) return authCheck;
+
+        return await ExecuteAsync(async () =>
+        {
+            var recipients = await _marketingService.GetRecipientsAsync(id, page, pageSize);
+            return new { recipients = recipients.Select(r => new { r.UserId, r.Email }), page, pageSize };
+        }, "GetRecipients");
+    }
+
+    [HttpGet("{id:guid}/logs")]
+    public async Task<IActionResult> GetLogs(Guid id, [FromQuery] int page = 1, [FromQuery] int pageSize = 50)
+    {
+        var authCheck = ValidateAuthentication();
+        if (authCheck != null) return authCheck;
+
+        var (logs, total) = await _marketingService.GetLogsAsync(id, page, pageSize);
+        return SuccessResponse(new
+        {
+            logs = logs.Select(EmailLogDto.From),
+            totalCount = total,
+            page,
+            pageSize
+        });
+    }
+
+    /// <summary>
+    /// Returns the fully-rendered HTML for a campaign email, for preview in a browser or iframe.
+    /// </summary>
+    [HttpGet("{id:guid}/preview")]
+    public async Task<IActionResult> PreviewEmail(Guid id)
+    {
+        var authCheck = ValidateAuthentication();
+        if (authCheck != null) return authCheck;
+
+        var campaign = await _marketingService.GetCampaignAsync(id);
+        if (campaign == null) return NotFoundResponse("Campaign", id);
+
+        var html = _emailService.RenderMarketingEmailPreview(campaign.Subject, campaign.HtmlBody);
+        return Content(html, "text/html");
+    }
+
+    [HttpPost("segments/preview")]
+    public async Task<IActionResult> PreviewSegment([FromBody] SegmentPreviewRequest request)
+    {
+        var authCheck = ValidateAuthentication();
+        if (authCheck != null) return authCheck;
+
+        return await ExecuteAsync(async () =>
+        {
+            if (!await _segmentService.IsValidSegmentFilter(request.SegmentFilter))
+                throw new ArgumentException($"Unknown segment filter: {request.SegmentFilter}");
+
+            var count = await _segmentService.GetSegmentCountAsync(request.SegmentFilter);
+            return new { segmentFilter = request.SegmentFilter, count };
+        }, "PreviewSegment");
+    }
+}

--- a/AI.ProfilePhotoMaker.API/Controllers/MarketingUnsubscribeController.cs
+++ b/AI.ProfilePhotoMaker.API/Controllers/MarketingUnsubscribeController.cs
@@ -1,0 +1,99 @@
+using AI.ProfilePhotoMaker.API.Data;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace AI.ProfilePhotoMaker.API.Controllers;
+
+[ApiController]
+[Route("api/user/marketing")]
+public class MarketingUnsubscribeController : BaseController
+{
+    private readonly ApplicationDbContext _db;
+
+    public MarketingUnsubscribeController(
+        ApplicationDbContext db,
+        ILogger<MarketingUnsubscribeController> logger)
+        : base(logger, db)
+    {
+        _db = db;
+    }
+
+    /// <summary>
+    /// Unsubscribe a user from marketing emails via token embedded in emails.
+    /// Accepts GET (link click) or POST (programmatic).
+    /// </summary>
+    [HttpGet("unsubscribe")]
+    [HttpPost("unsubscribe")]
+    public async Task<IActionResult> Unsubscribe([FromQuery] string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+            return ValidationError("Missing unsubscribe token");
+
+        string userId;
+        try
+        {
+            var decoded = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(token));
+            userId = decoded.Split(':')[0];
+        }
+        catch
+        {
+            return ValidationError("Invalid unsubscribe token");
+        }
+
+        if (string.IsNullOrWhiteSpace(userId) || userId == "test")
+            return SuccessResponse(new { unsubscribed = true });
+
+        var user = await _db.Users.FindAsync(userId);
+        if (user == null) return NotFoundResponse("User");
+
+        if (!user.MarketingOptOut)
+        {
+            user.MarketingOptOut = true;
+            user.MarketingOptOutAt = DateTime.UtcNow;
+            await _db.SaveChangesAsync();
+            Logger.LogInformation("User {UserId} unsubscribed from marketing emails", Sid(userId));
+        }
+
+        return SuccessResponse(new { unsubscribed = true });
+    }
+
+    /// <summary>
+    /// Returns the current user's marketing opt-out status.
+    /// </summary>
+    [HttpGet("status")]
+    [Microsoft.AspNetCore.Authorization.Authorize]
+    public async Task<IActionResult> GetStatus()
+    {
+        var authCheck = ValidateAuthentication();
+        if (authCheck != null) return authCheck;
+
+        var userId = GetCurrentUserId()!;
+        var user = await _db.Users.Where(u => u.Id == userId)
+            .Select(u => new { u.MarketingOptOut, u.MarketingOptOutAt })
+            .FirstOrDefaultAsync();
+
+        if (user == null) return NotFoundResponse("User");
+        return SuccessResponse(new { optedOut = user.MarketingOptOut, optedOutAt = user.MarketingOptOutAt });
+    }
+
+    /// <summary>
+    /// Re-subscribe the current authenticated user to marketing emails.
+    /// </summary>
+    [HttpPost("resubscribe")]
+    [Microsoft.AspNetCore.Authorization.Authorize]
+    public async Task<IActionResult> Resubscribe()
+    {
+        var authCheck = ValidateAuthentication();
+        if (authCheck != null) return authCheck;
+
+        var userId = GetCurrentUserId()!;
+        var user = await _db.Users.FindAsync(userId);
+        if (user == null) return NotFoundResponse("User");
+
+        user.MarketingOptOut = false;
+        user.MarketingOptOutAt = null;
+        await _db.SaveChangesAsync();
+
+        return SuccessResponse(new { resubscribed = true });
+    }
+}

--- a/AI.ProfilePhotoMaker.API/Controllers/PostmarkWebhookController.cs
+++ b/AI.ProfilePhotoMaker.API/Controllers/PostmarkWebhookController.cs
@@ -1,0 +1,169 @@
+using System.Text.Json;
+using AI.ProfilePhotoMaker.API.Configuration;
+using AI.ProfilePhotoMaker.API.Data;
+using AI.ProfilePhotoMaker.API.Infrastructure.Logging;
+using AI.ProfilePhotoMaker.API.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace AI.ProfilePhotoMaker.API.Controllers;
+
+/// <summary>
+/// Receives Postmark delivery event webhooks (bounce, spam complaint).
+/// Configure the Postmark webhook URL to:
+///   POST https://api.aiprofilephotomaker.com/api/webhooks/postmark
+/// And set the Authorization header to: Bearer {Email:PostmarkWebhookSecret}
+/// </summary>
+[ApiController]
+[AllowAnonymous]
+[Route("api/webhooks/postmark")]
+public class PostmarkWebhookController : ControllerBase
+{
+    private readonly ApplicationDbContext _db;
+    private readonly EmailOptions _emailOptions;
+    private readonly ILogger<PostmarkWebhookController> _logger;
+    private static string S(string? v) => LoggingSanitizer.Sanitize(v);
+    private static string Sid(string? v) => LoggingSanitizer.SanitizeId(v);
+
+    public PostmarkWebhookController(
+        ApplicationDbContext db,
+        IOptions<EmailOptions> emailOptions,
+        ILogger<PostmarkWebhookController> logger)
+    {
+        _db = db;
+        _emailOptions = emailOptions.Value;
+        _logger = logger;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Receive(CancellationToken cancellationToken)
+    {
+        // Verify shared secret if configured
+        if (!string.IsNullOrWhiteSpace(_emailOptions.PostmarkWebhookSecret))
+        {
+            var authHeader = Request.Headers.Authorization.ToString();
+            var expected = $"Bearer {_emailOptions.PostmarkWebhookSecret}";
+            if (!string.Equals(authHeader, expected, StringComparison.Ordinal))
+            {
+                _logger.LogWarning("Postmark webhook received with invalid Authorization header");
+                return Unauthorized();
+            }
+        }
+
+        string body;
+        using (var reader = new System.IO.StreamReader(Request.Body))
+        {
+            body = await reader.ReadToEndAsync(cancellationToken);
+        }
+
+        JsonElement root;
+        try
+        {
+            root = JsonSerializer.Deserialize<JsonElement>(body);
+        }
+        catch
+        {
+            _logger.LogWarning("Postmark webhook: failed to parse JSON body");
+            return BadRequest();
+        }
+
+        var recordType = root.TryGetProperty("RecordType", out var rt) ? rt.GetString() : null;
+        var email = root.TryGetProperty("Email", out var em) ? em.GetString() : null;
+
+        if (string.IsNullOrWhiteSpace(recordType) || string.IsNullOrWhiteSpace(email))
+        {
+            _logger.LogWarning("Postmark webhook: missing RecordType or Email");
+            return Ok(); // Return 200 so Postmark doesn't retry
+        }
+
+        _logger.LogInformation("Postmark webhook received: {RecordType} for {Email}", recordType, S(email));
+
+        switch (recordType)
+        {
+            case "Bounce":
+                var bounceType = root.TryGetProperty("Type", out var bt) ? bt.GetString() : null;
+                await HandleBounceAsync(email, bounceType, cancellationToken);
+                break;
+
+            case "SpamComplaint":
+                await HandleSpamComplaintAsync(email, cancellationToken);
+                break;
+
+            case "SubscriptionChange":
+                var suppressed = root.TryGetProperty("SuppressSending", out var ss) && ss.GetBoolean();
+                if (suppressed)
+                    await HandleUnsubscribeAsync(email, "SubscriptionChange", cancellationToken);
+                break;
+
+            default:
+                _logger.LogDebug("Postmark webhook: unhandled RecordType {RecordType}", recordType);
+                break;
+        }
+
+        return Ok(new { received = true });
+    }
+
+    private async Task HandleBounceAsync(string email, string? bounceType, CancellationToken ct)
+    {
+        // Hard bounces indicate the address is permanently invalid — auto-unsubscribe
+        var isHard = bounceType is "HardBounce" or "BadEmailAddress" or "ManuallyDeactivated";
+
+        // Update any pending/sent marketing logs for this email
+        var logs = await _db.MarketingEmailLogs
+            .Where(l => l.Email == email && l.Status == MarketingEmailStatus.Sent)
+            .ToListAsync(ct);
+
+        foreach (var log in logs)
+            log.Status = MarketingEmailStatus.Bounced;
+
+        if (isHard)
+        {
+            await HandleUnsubscribeAsync(email, $"HardBounce:{bounceType}", ct);
+        }
+        else if (logs.Count > 0)
+        {
+            await _db.SaveChangesAsync(ct);
+        }
+
+        _logger.LogInformation(
+            "Postmark bounce ({BounceType}) for {Email}: {LogCount} log(s) updated, unsubscribed={Unsubscribed}",
+            bounceType, S(email), logs.Count, isHard);
+    }
+
+    private Task HandleSpamComplaintAsync(string email, CancellationToken ct)
+        => HandleUnsubscribeAsync(email, "SpamComplaint", ct);
+
+    private async Task HandleUnsubscribeAsync(string email, string reason, CancellationToken ct)
+    {
+        var user = await _db.Users
+            .FirstOrDefaultAsync(u => u.Email == email, ct);
+
+        if (user == null)
+        {
+            _logger.LogInformation("Postmark {Reason}: no user found for {Email}", reason, S(email));
+            return;
+        }
+
+        if (!user.MarketingOptOut)
+        {
+            user.MarketingOptOut = true;
+            user.MarketingOptOutAt = DateTime.UtcNow;
+        }
+
+        // Also mark any pending logs as unsubscribed
+        var pendingLogs = await _db.MarketingEmailLogs
+            .Where(l => l.UserId == user.Id && l.Status == MarketingEmailStatus.Pending)
+            .ToListAsync(ct);
+
+        foreach (var log in pendingLogs)
+            log.Status = MarketingEmailStatus.Unsubscribed;
+
+        await _db.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "Postmark {Reason}: user {UserId} opted out of marketing",
+            reason, Sid(user.Id));
+    }
+}

--- a/AI.ProfilePhotoMaker.API/Data/ApplicationDbContext.cs
+++ b/AI.ProfilePhotoMaker.API/Data/ApplicationDbContext.cs
@@ -44,6 +44,10 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     public virtual DbSet<Coupon> Coupons { get; set; }
     public virtual DbSet<CouponRedemption> CouponRedemptions { get; set; }
 
+    // Marketing
+    public virtual DbSet<MarketingCampaign> MarketingCampaigns { get; set; }
+    public virtual DbSet<MarketingEmailLog> MarketingEmailLogs { get; set; }
+
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);
@@ -63,6 +67,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
         ConfigureRetentionDeletionWarningLogRelationships(builder);
         ConfigureAbandonedUploadNudgeLogRelationships(builder);
         ConfigurePredictionRelationships(builder);
+        ConfigureMarketingRelationships(builder);
 
         // Configure indexes for performance - ENHANCED FOR OPTIMIZATION
         ConfigurePerformanceIndexes(builder);
@@ -432,6 +437,35 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
         builder.Entity<CouponRedemption>()
             .Property(r => r.FinalPrice)
             .HasPrecision(10, 2);
+    }
+
+    private void ConfigureMarketingRelationships(ModelBuilder builder)
+    {
+        builder.Entity<MarketingCampaign>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Name).HasMaxLength(200).IsRequired();
+            entity.Property(e => e.Subject).HasMaxLength(300).IsRequired();
+            entity.Property(e => e.SegmentFilter).HasMaxLength(50).IsRequired();
+        });
+
+        builder.Entity<MarketingEmailLog>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.UserId).HasMaxLength(450).IsRequired();
+            entity.Property(e => e.Email).HasMaxLength(256).IsRequired();
+            entity.HasOne(e => e.Campaign)
+                  .WithMany()
+                  .HasForeignKey(e => e.CampaignId)
+                  .OnDelete(DeleteBehavior.Cascade);
+            entity.HasIndex(e => e.CampaignId).HasDatabaseName("IX_MarketingEmailLogs_CampaignId");
+            entity.HasIndex(e => e.UserId).HasDatabaseName("IX_MarketingEmailLogs_UserId");
+            entity.HasIndex(e => e.Status).HasDatabaseName("IX_MarketingEmailLogs_Status");
+            // Unique constraint: one log entry per user per campaign
+            entity.HasIndex(e => new { e.CampaignId, e.UserId })
+                  .IsUnique()
+                  .HasDatabaseName("UX_MarketingEmailLogs_CampaignId_UserId");
+        });
     }
 
     private void SeedCreditPackages(ModelBuilder builder)

--- a/AI.ProfilePhotoMaker.API/Extensions/PaymentServiceExtensions.cs
+++ b/AI.ProfilePhotoMaker.API/Extensions/PaymentServiceExtensions.cs
@@ -1,5 +1,6 @@
 using AI.ProfilePhotoMaker.API.Configuration;
 using AI.ProfilePhotoMaker.API.Services;
+using AI.ProfilePhotoMaker.API.Services.Marketing;
 using AI.ProfilePhotoMaker.API.Services.Payments;
 using Microsoft.Extensions.Options;
 
@@ -68,6 +69,11 @@ public static class PaymentServiceExtensions
         services.AddScoped<IPendingGenerationService, PendingGenerationService>();
 
         services.Configure<LegacyCompatibilityOptions>(configuration.GetSection(LegacyCompatibilityOptions.SectionName));
+
+        // Marketing email services
+        services.Configure<MarketingEmailOptions>(configuration.GetSection(MarketingEmailOptions.SectionName));
+        services.AddScoped<IUserSegmentService, UserSegmentService>();
+        services.AddScoped<IMarketingEmailService, MarketingEmailService>();
 
         return services;
     }

--- a/AI.ProfilePhotoMaker.API/Migrations/20260408121713_AddMarketingEmailService.Designer.cs
+++ b/AI.ProfilePhotoMaker.API/Migrations/20260408121713_AddMarketingEmailService.Designer.cs
@@ -4,6 +4,7 @@ using AI.ProfilePhotoMaker.API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AI.ProfilePhotoMaker.API.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260408121713_AddMarketingEmailService")]
+    partial class AddMarketingEmailService
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AI.ProfilePhotoMaker.API/Migrations/20260408121713_AddMarketingEmailService.cs
+++ b/AI.ProfilePhotoMaker.API/Migrations/20260408121713_AddMarketingEmailService.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AI.ProfilePhotoMaker.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMarketingEmailService : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "MarketingOptOut",
+                table: "AspNetUsers",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "MarketingOptOutAt",
+                table: "AspNetUsers",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "MarketingCampaigns",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Subject = table.Column<string>(type: "nvarchar(300)", maxLength: 300, nullable: false),
+                    HtmlBody = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    SegmentFilter = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    ScheduledAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    RecipientCount = table.Column<int>(type: "int", nullable: false),
+                    SentCount = table.Column<int>(type: "int", nullable: false),
+                    FailedCount = table.Column<int>(type: "int", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    StartedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    CompletedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MarketingCampaigns", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MarketingEmailLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CampaignId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: false),
+                    Email = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    ErrorMessage = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    SentAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MarketingEmailLogs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MarketingEmailLogs_MarketingCampaigns_CampaignId",
+                        column: x => x.CampaignId,
+                        principalTable: "MarketingCampaigns",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MarketingEmailLogs_CampaignId",
+                table: "MarketingEmailLogs",
+                column: "CampaignId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MarketingEmailLogs_Status",
+                table: "MarketingEmailLogs",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MarketingEmailLogs_UserId",
+                table: "MarketingEmailLogs",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_MarketingEmailLogs_CampaignId_UserId",
+                table: "MarketingEmailLogs",
+                columns: new[] { "CampaignId", "UserId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MarketingEmailLogs");
+
+            migrationBuilder.DropTable(
+                name: "MarketingCampaigns");
+
+            migrationBuilder.DropColumn(
+                name: "MarketingOptOut",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "MarketingOptOutAt",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/AI.ProfilePhotoMaker.API/Models/ApplicationUser.cs
+++ b/AI.ProfilePhotoMaker.API/Models/ApplicationUser.cs
@@ -8,6 +8,8 @@ public class ApplicationUser : IdentityUser
     public string FirstName { get; set; } = string.Empty;
     public string LastName { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public bool MarketingOptOut { get; set; } = false;
+    public DateTime? MarketingOptOutAt { get; set; }
 
     // Default parameterless constructor - required by EF Core
     public ApplicationUser() : base()

--- a/AI.ProfilePhotoMaker.API/Models/DTOs/MarketingDtos.cs
+++ b/AI.ProfilePhotoMaker.API/Models/DTOs/MarketingDtos.cs
@@ -1,0 +1,114 @@
+using AI.ProfilePhotoMaker.API.Models;
+
+namespace AI.ProfilePhotoMaker.API.Models.DTOs;
+
+public class CreateCampaignRequest
+{
+    public string Name { get; set; } = null!;
+    public string Subject { get; set; } = null!;
+    public string HtmlBody { get; set; } = null!;
+    public string SegmentFilter { get; set; } = null!;
+    public DateTime? ScheduledAt { get; set; }
+}
+
+public class UpdateCampaignRequest
+{
+    public string? Name { get; set; }
+    public string? Subject { get; set; }
+    public string? HtmlBody { get; set; }
+    public string? SegmentFilter { get; set; }
+}
+
+public class ScheduleCampaignRequest
+{
+    public DateTime ScheduledAt { get; set; }
+}
+
+public class SendTestRequest
+{
+    public string TestEmail { get; set; } = null!;
+}
+
+public class SegmentPreviewRequest
+{
+    public string SegmentFilter { get; set; } = null!;
+}
+
+public class CampaignDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+    public string Subject { get; set; } = null!;
+    public string SegmentFilter { get; set; } = null!;
+    public DateTime? ScheduledAt { get; set; }
+    public string Status { get; set; } = null!;
+    public int RecipientCount { get; set; }
+    public int SentCount { get; set; }
+    public int FailedCount { get; set; }
+    public string? CreatedBy { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? StartedAt { get; set; }
+    public DateTime? CompletedAt { get; set; }
+
+    public static CampaignDto From(MarketingCampaign c) => new()
+    {
+        Id = c.Id,
+        Name = c.Name,
+        Subject = c.Subject,
+        SegmentFilter = c.SegmentFilter,
+        ScheduledAt = c.ScheduledAt,
+        Status = c.Status.ToString(),
+        RecipientCount = c.RecipientCount,
+        SentCount = c.SentCount,
+        FailedCount = c.FailedCount,
+        CreatedBy = c.CreatedBy,
+        CreatedAt = c.CreatedAt,
+        StartedAt = c.StartedAt,
+        CompletedAt = c.CompletedAt,
+    };
+}
+
+public class CampaignDetailDto : CampaignDto
+{
+    public string HtmlBody { get; set; } = null!;
+
+    public new static CampaignDetailDto From(MarketingCampaign c) => new()
+    {
+        Id = c.Id,
+        Name = c.Name,
+        Subject = c.Subject,
+        HtmlBody = c.HtmlBody,
+        SegmentFilter = c.SegmentFilter,
+        ScheduledAt = c.ScheduledAt,
+        Status = c.Status.ToString(),
+        RecipientCount = c.RecipientCount,
+        SentCount = c.SentCount,
+        FailedCount = c.FailedCount,
+        CreatedBy = c.CreatedBy,
+        CreatedAt = c.CreatedAt,
+        StartedAt = c.StartedAt,
+        CompletedAt = c.CompletedAt,
+    };
+}
+
+public class EmailLogDto
+{
+    public Guid Id { get; set; }
+    public string UserId { get; set; } = null!;
+    public string Email { get; set; } = null!;
+    public string Status { get; set; } = null!;
+    public string? ErrorMessage { get; set; }
+    public DateTime? SentAt { get; set; }
+    public DateTime CreatedAt { get; set; }
+
+    public static EmailLogDto From(MarketingEmailLog l) => new()
+    {
+        Id = l.Id,
+        UserId = l.UserId,
+        Email = l.Email,
+        Status = l.Status.ToString(),
+        ErrorMessage = l.ErrorMessage,
+        SentAt = l.SentAt,
+        CreatedAt = l.CreatedAt,
+    };
+}

--- a/AI.ProfilePhotoMaker.API/Models/MarketingCampaign.cs
+++ b/AI.ProfilePhotoMaker.API/Models/MarketingCampaign.cs
@@ -1,0 +1,21 @@
+namespace AI.ProfilePhotoMaker.API.Models;
+
+public class MarketingCampaign
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = null!;
+    public string Subject { get; set; } = null!;
+    public string HtmlBody { get; set; } = null!;
+    public string SegmentFilter { get; set; } = null!;
+    public DateTime? ScheduledAt { get; set; }
+    public CampaignStatus Status { get; set; } = CampaignStatus.Draft;
+    public int RecipientCount { get; set; }
+    public int SentCount { get; set; }
+    public int FailedCount { get; set; }
+    public string? CreatedBy { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime? StartedAt { get; set; }
+    public DateTime? CompletedAt { get; set; }
+}
+
+public enum CampaignStatus { Draft, Scheduled, Sending, Sent, Cancelled }

--- a/AI.ProfilePhotoMaker.API/Models/MarketingEmailLog.cs
+++ b/AI.ProfilePhotoMaker.API/Models/MarketingEmailLog.cs
@@ -1,0 +1,16 @@
+namespace AI.ProfilePhotoMaker.API.Models;
+
+public class MarketingEmailLog
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid CampaignId { get; set; }
+    public MarketingCampaign Campaign { get; set; } = null!;
+    public string UserId { get; set; } = null!;
+    public string Email { get; set; } = null!;
+    public MarketingEmailStatus Status { get; set; } = MarketingEmailStatus.Pending;
+    public string? ErrorMessage { get; set; }
+    public DateTime? SentAt { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}
+
+public enum MarketingEmailStatus { Pending, Sent, Failed, Bounced, Unsubscribed }

--- a/AI.ProfilePhotoMaker.API/Program.cs
+++ b/AI.ProfilePhotoMaker.API/Program.cs
@@ -242,6 +242,7 @@ builder.Services.AddHostedService<TrainingPollingBackgroundService>();
 builder.Services.AddHostedService<AI.ProfilePhotoMaker.API.Services.BasicTierBackgroundService>();
 builder.Services.AddHostedService<AI.ProfilePhotoMaker.API.Services.RetentionPolicyBackgroundService>();
 builder.Services.AddHostedService<AI.ProfilePhotoMaker.API.Services.AbandonedUploadBackgroundService>();
+builder.Services.AddHostedService<AI.ProfilePhotoMaker.API.Services.Marketing.MarketingEmailBackgroundService>();
 
 // API behavior configuration
 builder.Services.Configure<ApiBehaviorOptions>(options =>

--- a/AI.ProfilePhotoMaker.API/Services/Marketing/FirstCampaignContent.cs
+++ b/AI.ProfilePhotoMaker.API/Services/Marketing/FirstCampaignContent.cs
@@ -1,0 +1,52 @@
+namespace AI.ProfilePhotoMaker.API.Services.Marketing;
+
+/// <summary>
+/// Provides the HTML content and metadata for the first marketing campaign:
+/// "You now only need 5 selfies" — targeting no-uploads and stuck-under-minimum users.
+/// </summary>
+public static class FirstCampaignContent
+{
+    public const string Name = "5 Selfie Minimum Launch";
+
+    public const string Subject = "Good news: you can now create AI headshots with just 5 photos";
+
+    public const string SegmentNoUploads = SegmentFilters.NoUploads;
+    public const string SegmentStuckUnderMinimum = SegmentFilters.StuckUnderMinimum;
+
+    public const string HtmlBody = @"
+<p>We heard you — getting 10+ selfies together was a real barrier.</p>
+<p><strong>We've lowered the minimum to just 5 selfies.</strong></p>
+<p>That's enough for our AI to learn your face and generate professional headshots in any style — LinkedIn, executive, casual, you name it.</p>
+<p style=""margin:16px 0;"">Here's what you'll get:</p>
+<ul style=""margin:0 0 16px; padding-left:20px; line-height:1.8;"">
+  <li>AI-trained model built from your 5+ selfies</li>
+  <li>Unlimited styled generations (credits permitting)</li>
+  <li>LinkedIn, executive, casual, and 20+ styles</li>
+  <li>Ready in minutes, not hours</li>
+</ul>
+<p>
+  <a href=""https://aiprofilephotomaker.com/dashboard""
+     style=""display:inline-block; background:#0ea5e9; color:#ffffff; text-decoration:none;
+            padding:12px 24px; border-radius:8px; font-weight:600; font-size:16px;"">
+    Get my headshots now
+  </a>
+</p>
+<p style=""margin-top:16px; font-size:14px; color:#64748b;"">
+  Already uploaded photos? You may already be eligible — just head to your dashboard to check.
+</p>";
+
+    /// <summary>
+    /// Returns the CreateCampaignRequest payload for this campaign, ready to POST.
+    /// Pass the desired segment filter (no-uploads or stuck-under-minimum).
+    /// </summary>
+    public static object BuildRequest(string segmentFilter, DateTime? scheduledAt = null) => new
+    {
+        name = segmentFilter == SegmentFilters.NoUploads
+            ? $"{Name} — Never Uploaded"
+            : $"{Name} — 1-4 Uploads",
+        subject = Subject,
+        htmlBody = HtmlBody,
+        segmentFilter,
+        scheduledAt
+    };
+}

--- a/AI.ProfilePhotoMaker.API/Services/Marketing/IMarketingEmailService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/Marketing/IMarketingEmailService.cs
@@ -1,0 +1,19 @@
+using AI.ProfilePhotoMaker.API.Models;
+using AI.ProfilePhotoMaker.API.Models.DTOs;
+
+namespace AI.ProfilePhotoMaker.API.Services.Marketing;
+
+public interface IMarketingEmailService
+{
+    Task<MarketingCampaign> CreateCampaignAsync(CreateCampaignRequest request, string createdBy);
+    Task<MarketingCampaign?> GetCampaignAsync(Guid campaignId);
+    Task<(IEnumerable<MarketingCampaign> Campaigns, int TotalCount)> GetCampaignsAsync(int page, int pageSize);
+    Task<MarketingCampaign> UpdateCampaignAsync(Guid campaignId, UpdateCampaignRequest request);
+    Task ScheduleCampaignAsync(Guid campaignId, DateTime scheduledAt);
+    Task CancelCampaignAsync(Guid campaignId);
+    Task<MarketingCampaign> DuplicateCampaignAsync(Guid campaignId, string createdBy);
+    Task SendTestAsync(Guid campaignId, string testEmail);
+    Task ExecuteCampaignAsync(Guid campaignId, CancellationToken cancellationToken = default);
+    Task<(IEnumerable<MarketingEmailLog> Logs, int TotalCount)> GetLogsAsync(Guid campaignId, int page, int pageSize);
+    Task<IEnumerable<(string UserId, string Email)>> GetRecipientsAsync(Guid campaignId, int page, int pageSize);
+}

--- a/AI.ProfilePhotoMaker.API/Services/Marketing/IUserSegmentService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/Marketing/IUserSegmentService.cs
@@ -1,0 +1,22 @@
+namespace AI.ProfilePhotoMaker.API.Services.Marketing;
+
+public interface IUserSegmentService
+{
+    Task<int> GetSegmentCountAsync(string segmentFilter);
+    Task<IEnumerable<(string UserId, string Email)>> GetSegmentUsersAsync(string segmentFilter, int page, int pageSize);
+    Task<bool> IsValidSegmentFilter(string segmentFilter);
+}
+
+public static class SegmentFilters
+{
+    public const string NoUploads = "no-uploads";
+    public const string StuckUnderMinimum = "stuck-under-minimum";
+    public const string HasUploadsNoModel = "has-uploads-no-model";
+    public const string Inactive30d = "inactive-30d";
+    public const string AllVerified = "all-verified";
+
+    public static readonly IReadOnlyList<string> All = new[]
+    {
+        NoUploads, StuckUnderMinimum, HasUploadsNoModel, Inactive30d, AllVerified
+    };
+}

--- a/AI.ProfilePhotoMaker.API/Services/Marketing/MarketingEmailBackgroundService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/Marketing/MarketingEmailBackgroundService.cs
@@ -1,0 +1,99 @@
+using AI.ProfilePhotoMaker.API.Configuration;
+using AI.ProfilePhotoMaker.API.Data;
+using AI.ProfilePhotoMaker.API.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace AI.ProfilePhotoMaker.API.Services.Marketing;
+
+public class MarketingEmailBackgroundService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<MarketingEmailBackgroundService> _logger;
+    private readonly MarketingEmailOptions _options;
+
+    public MarketingEmailBackgroundService(
+        IServiceProvider serviceProvider,
+        ILogger<MarketingEmailBackgroundService> logger,
+        IOptions<MarketingEmailOptions> options)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Marketing Email Background Service started");
+
+        try
+        {
+            await Task.Delay(_options.InitialDelay, stoppingToken);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await ProcessScheduledCampaigns(stoppingToken);
+                    await Task.Delay(_options.CheckInterval, stoppingToken);
+                }
+                catch (TaskCanceledException) { break; }
+                catch (OperationCanceledException) { break; }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Marketing email background service encountered an error");
+                    try { await Task.Delay(_options.ErrorRetryDelay, stoppingToken); }
+                    catch (OperationCanceledException) { break; }
+                }
+            }
+        }
+        catch (TaskCanceledException) { }
+        catch (OperationCanceledException) { }
+
+        _logger.LogInformation("Marketing Email Background Service stopped");
+    }
+
+    internal async Task ProcessScheduledCampaigns(CancellationToken cancellationToken = default)
+    {
+        if (!_options.Enabled) return;
+
+        using var scope = _serviceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var marketingService = scope.ServiceProvider.GetRequiredService<IMarketingEmailService>();
+
+        var now = DateTime.UtcNow;
+        var campaignsDue = await db.MarketingCampaigns
+            .Where(c => c.Status == CampaignStatus.Scheduled && c.ScheduledAt <= now)
+            .OrderBy(c => c.ScheduledAt)
+            .Select(c => c.Id)
+            .ToListAsync(cancellationToken);
+
+        if (campaignsDue.Count == 0) return;
+
+        _logger.LogInformation("Found {Count} campaign(s) due for sending", campaignsDue.Count);
+
+        foreach (var campaignId in campaignsDue)
+        {
+            if (cancellationToken.IsCancellationRequested) break;
+
+            try
+            {
+                await marketingService.ExecuteCampaignAsync(campaignId, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to execute campaign {CampaignId}", campaignId);
+            }
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Marketing Email Background Service is stopping");
+        await base.StopAsync(cancellationToken);
+    }
+}

--- a/AI.ProfilePhotoMaker.API/Services/Marketing/MarketingEmailService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/Marketing/MarketingEmailService.cs
@@ -1,0 +1,272 @@
+using AI.ProfilePhotoMaker.API.Configuration;
+using AI.ProfilePhotoMaker.API.Data;
+using AI.ProfilePhotoMaker.API.Models;
+using AI.ProfilePhotoMaker.API.Models.DTOs;
+using AI.ProfilePhotoMaker.API.Services.Notifications;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace AI.ProfilePhotoMaker.API.Services.Marketing;
+
+public class MarketingEmailService : IMarketingEmailService
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IEmailNotificationService _emailService;
+    private readonly IUserSegmentService _segmentService;
+    private readonly EmailOptions _emailOptions;
+    private readonly MarketingEmailOptions _marketingOptions;
+    private readonly ILogger<MarketingEmailService> _logger;
+
+    public MarketingEmailService(
+        ApplicationDbContext db,
+        IEmailNotificationService emailService,
+        IUserSegmentService segmentService,
+        IOptions<EmailOptions> emailOptions,
+        IOptions<MarketingEmailOptions> marketingOptions,
+        ILogger<MarketingEmailService> logger)
+    {
+        _db = db;
+        _emailService = emailService;
+        _segmentService = segmentService;
+        _emailOptions = emailOptions.Value;
+        _marketingOptions = marketingOptions.Value;
+        _logger = logger;
+    }
+
+    public async Task<MarketingCampaign> CreateCampaignAsync(CreateCampaignRequest request, string createdBy)
+    {
+        if (!await _segmentService.IsValidSegmentFilter(request.SegmentFilter))
+            throw new ArgumentException($"Unknown segment filter: {request.SegmentFilter}");
+
+        var campaign = new MarketingCampaign
+        {
+            Name = request.Name,
+            Subject = request.Subject,
+            HtmlBody = request.HtmlBody,
+            SegmentFilter = request.SegmentFilter,
+            ScheduledAt = request.ScheduledAt,
+            Status = request.ScheduledAt.HasValue ? CampaignStatus.Scheduled : CampaignStatus.Draft,
+            CreatedBy = createdBy,
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        if (campaign.Status == CampaignStatus.Scheduled)
+        {
+            campaign.RecipientCount = await _segmentService.GetSegmentCountAsync(request.SegmentFilter);
+        }
+
+        _db.MarketingCampaigns.Add(campaign);
+        await _db.SaveChangesAsync();
+        return campaign;
+    }
+
+    public Task<MarketingCampaign?> GetCampaignAsync(Guid campaignId)
+        => _db.MarketingCampaigns.FindAsync(campaignId).AsTask();
+
+    public async Task<(IEnumerable<MarketingCampaign> Campaigns, int TotalCount)> GetCampaignsAsync(int page, int pageSize)
+    {
+        var query = _db.MarketingCampaigns.OrderByDescending(c => c.CreatedAt);
+        var total = await query.CountAsync();
+        var items = await query.Skip((page - 1) * pageSize).Take(pageSize).ToListAsync();
+        return (items, total);
+    }
+
+    public async Task<MarketingCampaign> UpdateCampaignAsync(Guid campaignId, UpdateCampaignRequest request)
+    {
+        var campaign = await _db.MarketingCampaigns.FindAsync(campaignId)
+            ?? throw new KeyNotFoundException($"Campaign {campaignId} not found");
+
+        if (campaign.Status != CampaignStatus.Draft)
+            throw new InvalidOperationException("Only Draft campaigns can be updated");
+
+        if (request.Name != null) campaign.Name = request.Name;
+        if (request.Subject != null) campaign.Subject = request.Subject;
+        if (request.HtmlBody != null) campaign.HtmlBody = request.HtmlBody;
+        if (request.SegmentFilter != null)
+        {
+            if (!await _segmentService.IsValidSegmentFilter(request.SegmentFilter))
+                throw new ArgumentException($"Unknown segment filter: {request.SegmentFilter}");
+            campaign.SegmentFilter = request.SegmentFilter;
+        }
+
+        await _db.SaveChangesAsync();
+        return campaign;
+    }
+
+    public async Task ScheduleCampaignAsync(Guid campaignId, DateTime scheduledAt)
+    {
+        var campaign = await _db.MarketingCampaigns.FindAsync(campaignId)
+            ?? throw new KeyNotFoundException($"Campaign {campaignId} not found");
+
+        if (campaign.Status is not (CampaignStatus.Draft or CampaignStatus.Cancelled))
+            throw new InvalidOperationException($"Cannot schedule a campaign with status {campaign.Status}");
+
+        if (scheduledAt <= DateTime.UtcNow)
+            throw new ArgumentException("ScheduledAt must be in the future");
+
+        campaign.ScheduledAt = scheduledAt;
+        campaign.Status = CampaignStatus.Scheduled;
+        campaign.RecipientCount = await _segmentService.GetSegmentCountAsync(campaign.SegmentFilter);
+        await _db.SaveChangesAsync();
+    }
+
+    public async Task CancelCampaignAsync(Guid campaignId)
+    {
+        var campaign = await _db.MarketingCampaigns.FindAsync(campaignId)
+            ?? throw new KeyNotFoundException($"Campaign {campaignId} not found");
+
+        if (campaign.Status is not (CampaignStatus.Draft or CampaignStatus.Scheduled))
+            throw new InvalidOperationException($"Cannot cancel a campaign with status {campaign.Status}");
+
+        campaign.Status = CampaignStatus.Cancelled;
+        await _db.SaveChangesAsync();
+    }
+
+    public async Task<MarketingCampaign> DuplicateCampaignAsync(Guid campaignId, string createdBy)
+    {
+        var source = await _db.MarketingCampaigns.FindAsync(campaignId)
+            ?? throw new KeyNotFoundException($"Campaign {campaignId} not found");
+
+        var copy = new MarketingCampaign
+        {
+            Name = $"Copy of {source.Name}",
+            Subject = source.Subject,
+            HtmlBody = source.HtmlBody,
+            SegmentFilter = source.SegmentFilter,
+            Status = CampaignStatus.Draft,
+            CreatedBy = createdBy,
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        _db.MarketingCampaigns.Add(copy);
+        await _db.SaveChangesAsync();
+        return copy;
+    }
+
+    public async Task SendTestAsync(Guid campaignId, string testEmail)
+    {
+        var campaign = await _db.MarketingCampaigns.FindAsync(campaignId)
+            ?? throw new KeyNotFoundException($"Campaign {campaignId} not found");
+
+        var unsubscribeUrl = $"{_emailOptions.FrontendBaseUrl}/unsubscribe?token=test";
+        await _emailService.SendMarketingEmailAsync(
+            userId: "test",
+            email: testEmail,
+            subject: $"[TEST] {campaign.Subject}",
+            htmlBody: campaign.HtmlBody,
+            unsubscribeUrl: unsubscribeUrl);
+    }
+
+    public async Task ExecuteCampaignAsync(Guid campaignId, CancellationToken cancellationToken = default)
+    {
+        var campaign = await _db.MarketingCampaigns.FindAsync(campaignId)
+            ?? throw new KeyNotFoundException($"Campaign {campaignId} not found");
+
+        if (campaign.Status != CampaignStatus.Scheduled)
+            throw new InvalidOperationException($"Campaign {campaignId} is not in Scheduled state");
+
+        campaign.Status = CampaignStatus.Sending;
+        campaign.StartedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+
+        _logger.LogInformation("Starting campaign {CampaignId} ({Name})", campaignId, campaign.Name);
+
+        try
+        {
+            int page = 1;
+            int sent = 0, failed = 0;
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var recipients = (await _segmentService.GetSegmentUsersAsync(
+                    campaign.SegmentFilter, page, _marketingOptions.BatchSize)).ToList();
+
+                if (recipients.Count == 0) break;
+
+                foreach (var (userId, email) in recipients)
+                {
+                    if (cancellationToken.IsCancellationRequested) break;
+
+                    // Skip if already sent in this campaign
+                    var alreadySent = await _db.MarketingEmailLogs.AnyAsync(
+                        l => l.CampaignId == campaignId && l.UserId == userId, cancellationToken);
+                    if (alreadySent) continue;
+
+                    var log = new MarketingEmailLog
+                    {
+                        CampaignId = campaignId,
+                        UserId = userId,
+                        Email = email,
+                        Status = MarketingEmailStatus.Pending,
+                        CreatedAt = DateTime.UtcNow,
+                    };
+                    _db.MarketingEmailLogs.Add(log);
+                    await _db.SaveChangesAsync(cancellationToken);
+
+                    var unsubscribeToken = Convert.ToBase64String(
+                        System.Text.Encoding.UTF8.GetBytes($"{userId}:{campaignId}"));
+                    var unsubscribeUrl = $"{_emailOptions.FrontendBaseUrl}/unsubscribe?token={Uri.EscapeDataString(unsubscribeToken)}";
+
+                    var success = await _emailService.SendMarketingEmailAsync(
+                        userId, email, campaign.Subject, campaign.HtmlBody, unsubscribeUrl);
+
+                    log.Status = success ? MarketingEmailStatus.Sent : MarketingEmailStatus.Failed;
+                    log.SentAt = success ? DateTime.UtcNow : null;
+                    if (!success) log.ErrorMessage = "Send failed";
+                    await _db.SaveChangesAsync(cancellationToken);
+
+                    if (success) sent++; else failed++;
+                }
+
+                if (recipients.Count < _marketingOptions.BatchSize) break;
+                page++;
+
+                if (_marketingOptions.BatchDelayMs > 0)
+                    await Task.Delay(_marketingOptions.BatchDelayMs, cancellationToken);
+            }
+
+            campaign.SentCount = sent;
+            campaign.FailedCount = failed;
+            campaign.Status = CampaignStatus.Sent;
+            campaign.CompletedAt = DateTime.UtcNow;
+            await _db.SaveChangesAsync();
+
+            _logger.LogInformation(
+                "Campaign {CampaignId} completed: {Sent} sent, {Failed} failed",
+                campaignId, sent, failed);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning("Campaign {CampaignId} execution was cancelled", campaignId);
+            // Leave status as Sending so background service can resume or admin can retry
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Campaign {CampaignId} failed unexpectedly", campaignId);
+            campaign.Status = CampaignStatus.Scheduled; // Reset so it will retry
+            await _db.SaveChangesAsync();
+            throw;
+        }
+    }
+
+    public async Task<(IEnumerable<MarketingEmailLog> Logs, int TotalCount)> GetLogsAsync(
+        Guid campaignId, int page, int pageSize)
+    {
+        var query = _db.MarketingEmailLogs
+            .Where(l => l.CampaignId == campaignId)
+            .OrderByDescending(l => l.CreatedAt);
+        var total = await query.CountAsync();
+        var items = await query.Skip((page - 1) * pageSize).Take(pageSize).ToListAsync();
+        return (items, total);
+    }
+
+    public async Task<IEnumerable<(string UserId, string Email)>> GetRecipientsAsync(
+        Guid campaignId, int page, int pageSize)
+    {
+        var campaign = await _db.MarketingCampaigns.FindAsync(campaignId)
+            ?? throw new KeyNotFoundException($"Campaign {campaignId} not found");
+
+        return await _segmentService.GetSegmentUsersAsync(campaign.SegmentFilter, page, pageSize);
+    }
+}

--- a/AI.ProfilePhotoMaker.API/Services/Marketing/UserSegmentService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/Marketing/UserSegmentService.cs
@@ -1,0 +1,87 @@
+using AI.ProfilePhotoMaker.API.Data;
+using AI.ProfilePhotoMaker.API.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace AI.ProfilePhotoMaker.API.Services.Marketing;
+
+public class UserSegmentService : IUserSegmentService
+{
+    private readonly ApplicationDbContext _db;
+
+    public UserSegmentService(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    public Task<bool> IsValidSegmentFilter(string segmentFilter)
+        => Task.FromResult(SegmentFilters.All.Contains(segmentFilter));
+
+    public async Task<int> GetSegmentCountAsync(string segmentFilter)
+        => await BuildSegmentQuery(segmentFilter).CountAsync();
+
+    public async Task<IEnumerable<(string UserId, string Email)>> GetSegmentUsersAsync(
+        string segmentFilter, int page, int pageSize)
+    {
+        var results = await BuildSegmentQuery(segmentFilter)
+            .OrderBy(u => u.CreatedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(u => new { u.Id, u.Email })
+            .ToListAsync();
+
+        return results.Select(r => (r.Id, r.Email ?? string.Empty));
+    }
+
+    private IQueryable<ApplicationUser> BuildSegmentQuery(string segmentFilter)
+    {
+        // Base: email-verified, marketing opt-in
+        var baseQuery = _db.Users
+            .Where(u => u.EmailConfirmed && !u.MarketingOptOut && u.Email != null);
+
+        return segmentFilter switch
+        {
+            // Signed up + verified, never uploaded a single selfie
+            SegmentFilters.NoUploads =>
+                from u in baseQuery
+                where !_db.Set<ProcessedImage>()
+                    .Any(i => i.UserProfile.UserId == u.Id && i.IsOriginalUpload)
+                select u,
+
+            // Uploaded 1–4 selfies (previously blocked at 10-photo minimum, now eligible)
+            SegmentFilters.StuckUnderMinimum =>
+                from u in baseQuery
+                let uploadCount = _db.Set<ProcessedImage>()
+                    .Count(i => i.UserProfile.UserId == u.Id && i.IsOriginalUpload)
+                where uploadCount >= 1 && uploadCount <= 4
+                select u,
+
+            // 5+ uploads but never started training
+            SegmentFilters.HasUploadsNoModel =>
+                from u in baseQuery
+                let uploadCount = _db.Set<ProcessedImage>()
+                    .Count(i => i.UserProfile.UserId == u.Id && i.IsOriginalUpload)
+                where uploadCount >= 5
+                    && !_db.Set<ModelCreationRequest>().Any(m =>
+                        m.UserId == u.Id
+                        && (m.Status == ModelCreationStatus.Ready
+                            || m.Status == ModelCreationStatus.Creating
+                            || m.Status == ModelCreationStatus.Pending))
+                select u,
+
+            // Has uploads but no activity in the last 30 days
+            SegmentFilters.Inactive30d =>
+                from u in baseQuery
+                let cutoff = DateTime.UtcNow.AddDays(-30)
+                where _db.Set<ProcessedImage>()
+                          .Any(i => i.UserProfile.UserId == u.Id && i.IsOriginalUpload)
+                      && !_db.Set<UsageLog>()
+                          .Any(l => l.UserId == u.Id && l.CreatedAt >= cutoff)
+                select u,
+
+            // All verified, non-opted-out users
+            SegmentFilters.AllVerified => baseQuery,
+
+            _ => throw new ArgumentException($"Unknown segment filter: {segmentFilter}")
+        };
+    }
+}

--- a/AI.ProfilePhotoMaker.API/Services/Notifications/EmailNotificationService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/Notifications/EmailNotificationService.cs
@@ -241,6 +241,44 @@ public class EmailNotificationService : IEmailNotificationService
             replyToEmail: userEmail);
     }
 
+    public async Task<bool> SendMarketingEmailAsync(
+        string userId,
+        string email,
+        string subject,
+        string htmlBody,
+        string unsubscribeUrl)
+    {
+        if (!_options.Enabled) return false;
+
+        var safeUnsubscribeUrl = WebUtility.HtmlEncode(unsubscribeUrl);
+        var bodyWithFooter = htmlBody + $@"
+<p style=""margin:24px 0 0; font-size:13px; color:#64748b;"">
+  You're receiving this because you signed up for AI Profile Photo Maker.
+  <a href=""{safeUnsubscribeUrl}"" style=""color:#64748b; text-decoration:underline;"">Unsubscribe</a> from marketing emails.
+</p>";
+
+        try
+        {
+            await SendEmailAsync(email, subject, bodyWithFooter, "marketing", userId);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Failed to send marketing email for user {UserId}: {Reason}", Sid(userId), S(ex.Message));
+            return false;
+        }
+    }
+
+    public string RenderMarketingEmailPreview(string subject, string htmlBody)
+    {
+        var bodyWithFooter = htmlBody + @"
+<p style=""margin:24px 0 0; font-size:13px; color:#64748b;"">
+  You're receiving this because you signed up for AI Profile Photo Maker.
+  <a href=""#"" style=""color:#64748b; text-decoration:underline;"">Unsubscribe</a> from marketing emails.
+</p>";
+        return WrapEmail(subject, bodyWithFooter);
+    }
+
     private Task SendEmailAsync(string? toEmail, string subject, string htmlBody, string template, string? userId = null)
     {
         return SendEmailAsync(toEmail, subject, htmlBody, template, userId, replyToEmail: null, replyToName: null);

--- a/AI.ProfilePhotoMaker.API/Services/Notifications/IEmailNotificationService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/Notifications/IEmailNotificationService.cs
@@ -13,4 +13,6 @@ public interface IEmailNotificationService
     Task SendWelcomeAsync(string userId, string? email, string? firstName = null);
     Task SendRetentionDeletionWarningAsync(string userId, string? email, int imageCount, DateTime deletionDate, int daysUntilDeletion);
     Task SendAbandonedUploadNudgeAsync(string userId, string? email, string? firstName = null);
+    Task<bool> SendMarketingEmailAsync(string userId, string email, string subject, string htmlBody, string unsubscribeUrl);
+    string RenderMarketingEmailPreview(string subject, string htmlBody);
 }

--- a/AI.ProfilePhotoMaker.API/appsettings.LocalDev.json
+++ b/AI.ProfilePhotoMaker.API/appsettings.LocalDev.json
@@ -41,6 +41,9 @@
     "ClientId": "dummy.apps.googleusercontent.com",
     "ClientSecret": "dummy"
   },
+  "MarketingEmail": {
+    "Enabled": false
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/AI.ProfilePhotoMaker.API/appsettings.json
+++ b/AI.ProfilePhotoMaker.API/appsettings.json
@@ -71,7 +71,8 @@
     "SandboxMode": false,
     "FrontendBaseUrl": "https://aiprofilephotomaker.com",
     "SupportToEmail": "support@aiprofilephotomaker.com",
-    "SupportToName": "AI Profile Photo Maker Support"
+    "SupportToName": "AI Profile Photo Maker Support",
+    "PostmarkWebhookSecret": "REPLACE_WITH_POSTMARK_WEBHOOK_SECRET"
   },
   "ExternalApiBaseUrl": "https://api.aiprofilephotomaker.com",
   "Webhooks": {
@@ -118,6 +119,14 @@
   },
   "RetentionNotifications": {
     "NotificationDays": [14, 7]
+  },
+  "MarketingEmail": {
+    "Enabled": true,
+    "InitialDelay": "00:02:00",
+    "CheckInterval": "00:01:00",
+    "ErrorRetryDelay": "00:05:00",
+    "BatchSize": 50,
+    "BatchDelayMs": 1000
   },
   "AllowedHosts": "*",
   "Storage": {

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-audit-log/admin-audit-log.component.html
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-audit-log/admin-audit-log.component.html
@@ -12,6 +12,7 @@
     <a routerLink="/admin/users" routerLinkActive="is-active">Users</a>
     <a routerLink="/admin/coupons" routerLinkActive="is-active">Coupons</a>
     <a routerLink="/admin/audit-log" routerLinkActive="is-active">Audit Log</a>
+    <a routerLink="/admin/campaigns" routerLinkActive="is-active">Campaigns</a>
   </nav>
 
   <section class="admin-panel">

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-campaigns/admin-campaigns.component.html
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-campaigns/admin-campaigns.component.html
@@ -1,0 +1,265 @@
+<section class="admin-shell">
+  <header class="admin-header">
+    <div>
+      <p class="admin-kicker">Marketing</p>
+      <h1>Email Campaigns</h1>
+      <p class="admin-subtitle">Create, schedule, and track targeted marketing email campaigns.</p>
+    </div>
+    <button *ngIf="view === 'list'" class="btn btn-primary" (click)="showCreate()">+ New Campaign</button>
+    <button *ngIf="view !== 'list'" class="btn btn-ghost" (click)="backToList()">← Back</button>
+  </header>
+
+  <nav class="admin-nav">
+    <a routerLink="/admin/dashboard" routerLinkActive="is-active">Overview</a>
+    <a routerLink="/admin/users" routerLinkActive="is-active">Users</a>
+    <a routerLink="/admin/coupons" routerLinkActive="is-active">Coupons</a>
+    <a routerLink="/admin/audit-log" routerLinkActive="is-active">Audit Log</a>
+    <a routerLink="/admin/campaigns" routerLinkActive="is-active">Campaigns</a>
+  </nav>
+
+  <!-- Feedback -->
+  <div *ngIf="error" class="error-text" role="alert">{{ error }}</div>
+  <div *ngIf="success" class="success-text" role="status">{{ success }}</div>
+
+  <!-- Loading -->
+  <div *ngIf="isLoading" class="empty-state"><p>Loading…</p></div>
+
+  <!-- ─── LIST VIEW ────────────────────────────────────────── -->
+  <ng-container *ngIf="view === 'list' && !isLoading">
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Segment</th>
+            <th>Status</th>
+            <th>Scheduled</th>
+            <th>Recipients</th>
+            <th>Sent / Failed</th>
+            <th>Created</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let c of campaigns">
+            <td>
+              <strong>{{ c.name }}</strong>
+            </td>
+            <td class="mono-text">{{ c.segmentFilter }}</td>
+            <td>
+              <span class="pill" [ngClass]="statusPillClass(c.status)">{{ c.status }}</span>
+            </td>
+            <td>{{ c.scheduledAt ? (c.scheduledAt | date: 'MMM d, y HH:mm') : '—' }}</td>
+            <td>{{ c.recipientCount | number }}</td>
+            <td>{{ c.sentCount | number }} / {{ c.failedCount | number }}</td>
+            <td>{{ c.createdAt | date: 'MMM d' }}</td>
+            <td>
+              <div class="action-row">
+                <button class="btn btn-ghost btn-sm" (click)="openDetail(c.id)">Edit</button>
+                <button class="btn btn-ghost btn-sm" (click)="openPreview(c.id)">Preview</button>
+                <button class="btn btn-ghost btn-sm" (click)="openLogs(c.id)">Logs</button>
+                <button class="btn btn-ghost btn-sm" (click)="duplicateCampaign(c.id)">Dup</button>
+                <button *ngIf="canCancel(c.status)" class="btn btn-danger btn-sm" (click)="confirmCancelId = c.id">
+                  Cancel
+                </button>
+              </div>
+            </td>
+          </tr>
+          <tr *ngIf="campaigns.length === 0">
+            <td colspan="8" class="empty-state">No campaigns yet. Create your first one.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="pager" *ngIf="totalCount > pageSize">
+      <button class="btn btn-ghost btn-sm" (click)="prevPage()" [disabled]="page === 1">← Prev</button>
+      <span>Page {{ page }} of {{ totalPages }} ({{ totalCount | number }} campaigns)</span>
+      <button class="btn btn-ghost btn-sm" (click)="nextPage()" [disabled]="page === totalPages">Next →</button>
+    </div>
+
+    <!-- Confirm cancel -->
+    <section class="admin-panel danger-panel" *ngIf="confirmCancelId">
+      <h2>Cancel Campaign?</h2>
+      <p class="form-subtitle">This will move the campaign back to Cancelled state. You can reschedule it later.</p>
+      <div class="action-row">
+        <button class="btn btn-danger" (click)="cancelCampaign(confirmCancelId!)">Confirm Cancel</button>
+        <button class="btn btn-ghost" (click)="confirmCancelId = null">Never mind</button>
+      </div>
+    </section>
+  </ng-container>
+
+  <!-- ─── CREATE VIEW ──────────────────────────────────────── -->
+  <ng-container *ngIf="view === 'create'">
+    <section class="admin-panel">
+      <h2>New Campaign</h2>
+
+      <div class="field-grid">
+        <div class="field-group">
+          <label for="c-name">Internal Name</label>
+          <input id="c-name" [(ngModel)]="model.name" placeholder="5 Selfie Launch — No Uploads" />
+        </div>
+
+        <div class="field-group">
+          <label for="c-segment">Segment</label>
+          <select id="c-segment" [(ngModel)]="model.segmentFilter" (change)="segmentCount = null">
+            <option *ngFor="let s of segmentOptions" [value]="s.value">{{ s.label }}</option>
+          </select>
+        </div>
+
+        <div class="field-group field-span-2">
+          <label for="c-subject">Subject Line</label>
+          <input id="c-subject" [(ngModel)]="model.subject" />
+        </div>
+
+        <div class="field-group field-span-2">
+          <label for="c-body">HTML Body</label>
+          <textarea id="c-body" [(ngModel)]="model.htmlBody" rows="12" class="body-textarea"></textarea>
+        </div>
+
+        <div class="field-group">
+          <label for="c-scheduled">Schedule At (optional)</label>
+          <input id="c-scheduled" type="datetime-local" [(ngModel)]="model.scheduledAt" />
+        </div>
+
+        <div class="field-group segment-preview-group">
+          <p class="field-label">Recipient Estimate</p>
+          <div class="action-row">
+            <button class="btn btn-ghost btn-sm" (click)="previewSegmentCount()" [disabled]="segmentCounting">
+              {{ segmentCounting ? 'Counting…' : 'Count recipients' }}
+            </button>
+            <span *ngIf="segmentCount !== null" class="pill pill-credit">~{{ segmentCount | number }} recipients</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="action-row" style="margin-top: 1rem">
+        <button class="btn btn-primary" (click)="createCampaign()" [disabled]="isSaving">
+          {{ isSaving ? 'Saving…' : 'Create Campaign' }}
+        </button>
+        <button class="btn btn-ghost" (click)="backToList()">Cancel</button>
+      </div>
+    </section>
+  </ng-container>
+
+  <!-- ─── DETAIL VIEW ──────────────────────────────────────── -->
+  <ng-container *ngIf="view === 'detail' && selectedCampaign && !isLoading">
+    <section class="admin-panel">
+      <div class="detail-header">
+        <div>
+          <h2>{{ selectedCampaign.name }}</h2>
+          <span class="pill" [ngClass]="statusPillClass(selectedCampaign.status)">{{ selectedCampaign.status }}</span>
+        </div>
+        <div class="action-row">
+          <button class="btn btn-ghost btn-sm" (click)="openPreview(selectedCampaign.id)">Preview Email</button>
+          <button class="btn btn-ghost btn-sm" (click)="openLogs(selectedCampaign.id)">View Logs</button>
+          <button class="btn btn-ghost btn-sm" (click)="duplicateCampaign(selectedCampaign.id)">Duplicate</button>
+        </div>
+      </div>
+
+      <dl class="detail-grid">
+        <dt>Subject</dt>
+        <dd>{{ selectedCampaign.subject }}</dd>
+        <dt>Segment</dt>
+        <dd class="mono-text">{{ selectedCampaign.segmentFilter }}</dd>
+        <dt>Recipients</dt>
+        <dd>{{ selectedCampaign.recipientCount | number }}</dd>
+        <dt>Sent</dt>
+        <dd>{{ selectedCampaign.sentCount | number }}</dd>
+        <dt>Failed</dt>
+        <dd>{{ selectedCampaign.failedCount | number }}</dd>
+        <dt>Scheduled</dt>
+        <dd>{{ selectedCampaign.scheduledAt ? (selectedCampaign.scheduledAt | date: 'medium') : '—' }}</dd>
+        <dt>Started</dt>
+        <dd>{{ selectedCampaign.startedAt ? (selectedCampaign.startedAt | date: 'medium') : '—' }}</dd>
+        <dt>Completed</dt>
+        <dd>{{ selectedCampaign.completedAt ? (selectedCampaign.completedAt | date: 'medium') : '—' }}</dd>
+      </dl>
+    </section>
+
+    <!-- Schedule -->
+    <section class="admin-panel" *ngIf="canSchedule(selectedCampaign)">
+      <h2>Schedule Send</h2>
+      <div class="field-grid">
+        <div class="field-group">
+          <label for="sched-at">Send At</label>
+          <input id="sched-at" type="datetime-local" [(ngModel)]="scheduleDate" />
+        </div>
+      </div>
+      <div class="action-row" style="margin-top: 0.8rem">
+        <button class="btn btn-primary" (click)="scheduleCampaign()" [disabled]="isSaving || !scheduleDate">
+          {{ isSaving ? 'Scheduling…' : 'Schedule Campaign' }}
+        </button>
+      </div>
+    </section>
+
+    <!-- Test send -->
+    <section class="admin-panel">
+      <h2>Send Test Email</h2>
+      <div class="field-grid">
+        <div class="field-group">
+          <label for="test-email">Recipient Email</label>
+          <input id="test-email" type="email" [(ngModel)]="testEmail" placeholder="you@example.com" />
+        </div>
+      </div>
+      <div class="action-row" style="margin-top: 0.8rem">
+        <button class="btn btn-ghost" (click)="sendTest()" [disabled]="isSaving || !testEmail">
+          {{ isSaving ? 'Sending…' : 'Send Test' }}
+        </button>
+      </div>
+    </section>
+
+    <!-- Cancel -->
+    <section class="admin-panel danger-panel" *ngIf="canCancel(selectedCampaign.status)">
+      <h2>Cancel Campaign</h2>
+      <p class="form-subtitle">Move this campaign to Cancelled. You can reschedule it later.</p>
+      <div class="action-row">
+        <button class="btn btn-danger" (click)="confirmCancelId = selectedCampaign!.id" [disabled]="isSaving">
+          Cancel Campaign
+        </button>
+      </div>
+    </section>
+
+    <!-- Confirm cancel -->
+    <section class="admin-panel danger-panel" *ngIf="confirmCancelId === selectedCampaign.id">
+      <h2>Confirm Cancellation</h2>
+      <div class="action-row">
+        <button class="btn btn-danger" (click)="cancelCampaign(selectedCampaign.id)">Confirm</button>
+        <button class="btn btn-ghost" (click)="confirmCancelId = null">Never mind</button>
+      </div>
+    </section>
+  </ng-container>
+
+  <!-- ─── LOGS VIEW ────────────────────────────────────────── -->
+  <ng-container *ngIf="view === 'logs' && !isLoading">
+    <section class="admin-panel">
+      <h2>Delivery Logs</h2>
+      <p class="form-subtitle">Showing {{ logs.length | number }} of {{ logTotal | number }} entries.</p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Email</th>
+              <th>Status</th>
+              <th>Sent At</th>
+              <th>Error</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let l of logs">
+              <td class="mono-text">{{ l.email }}</td>
+              <td>
+                <span class="pill" [ngClass]="logStatusPillClass(l.status)">{{ l.status }}</span>
+              </td>
+              <td>{{ l.sentAt ? (l.sentAt | date: 'MMM d HH:mm') : '—' }}</td>
+              <td class="error-text">{{ l.errorMessage || '' }}</td>
+            </tr>
+            <tr *ngIf="logs.length === 0">
+              <td colspan="4" class="empty-state">No log entries yet.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </ng-container>
+</section>

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-campaigns/admin-campaigns.component.sass
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-campaigns/admin-campaigns.component.sass
@@ -1,0 +1,49 @@
+.detail-header
+  display: flex
+  justify-content: space-between
+  align-items: flex-start
+  flex-wrap: wrap
+  gap: 0.75rem
+  margin-bottom: 1rem
+
+  h2
+    margin: 0 0 0.35rem 0
+
+.detail-grid
+  display: grid
+  grid-template-columns: max-content 1fr
+  gap: 0.4rem 1rem
+  margin: 0
+
+  dt
+    font-size: 0.82rem
+    font-weight: 700
+    color: var(--text-tertiary)
+    text-transform: uppercase
+    letter-spacing: 0.06em
+
+  dd
+    margin: 0
+    font-size: 0.92rem
+
+.body-textarea
+  width: 100%
+  border: 1px solid var(--border-color)
+  border-radius: 10px
+  padding: 0.56rem 0.65rem
+  background: var(--input-bg)
+  color: var(--text-primary)
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace
+  font-size: 0.82rem
+  resize: vertical
+
+  &:focus
+    outline: none
+    border-color: var(--accent-primary)
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-primary) 28%, transparent)
+
+.segment-preview-group
+  align-items: flex-start
+
+.pill-warning
+  background: color-mix(in srgb, var(--accent-warning) 22%, transparent)

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-campaigns/admin-campaigns.component.ts
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-campaigns/admin-campaigns.component.ts
@@ -1,0 +1,357 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import {
+  MarketingService,
+  CampaignDto,
+  CampaignDetailDto,
+  CreateCampaignRequest,
+} from '../../services/marketing.service';
+
+const FIRST_CAMPAIGN_BODY = `<p>We heard you — getting 10+ selfies together was a real barrier.</p>
+<p><strong>We've lowered the minimum to just 5 selfies.</strong></p>
+<p>That's enough for our AI to learn your face and generate professional headshots in any style — LinkedIn, executive, casual, you name it.</p>
+<p style="margin:16px 0;">Here's what you'll get:</p>
+<ul style="margin:0 0 16px; padding-left:20px; line-height:1.8;">
+  <li>AI-trained model built from your 5+ selfies</li>
+  <li>Unlimited styled generations (credits permitting)</li>
+  <li>LinkedIn, executive, casual, and 20+ styles</li>
+  <li>Ready in minutes, not hours</li>
+</ul>
+<p>
+  <a href="https://aiprofilephotomaker.com/dashboard"
+     style="display:inline-block; background:#0ea5e9; color:#ffffff; text-decoration:none;
+            padding:12px 24px; border-radius:8px; font-weight:600; font-size:16px;">
+    Get my headshots now
+  </a>
+</p>
+<p style="margin-top:16px; font-size:14px; color:#64748b;">
+  Already uploaded photos? You may already be eligible — just head to your dashboard to check.
+</p>`;
+
+type View = 'list' | 'create' | 'detail' | 'logs';
+
+@Component({
+  selector: 'app-admin-campaigns',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterModule],
+  templateUrl: './admin-campaigns.component.html',
+  styleUrls: ['../admin-shared.sass', './admin-campaigns.component.sass'],
+})
+export class AdminCampaignsComponent implements OnInit, OnDestroy {
+  view: View = 'list';
+  campaigns: CampaignDto[] = [];
+  totalCount = 0;
+  page = 1;
+  pageSize = 20;
+
+  selectedCampaign: CampaignDetailDto | null = null;
+  logs: any[] = [];
+  logTotal = 0;
+  logPage = 1;
+
+  segmentCount: number | null = null;
+  segmentCounting = false;
+
+  model: CreateCampaignRequest = {
+    name: '',
+    subject: 'Good news: you can now create AI headshots with just 5 photos',
+    htmlBody: FIRST_CAMPAIGN_BODY,
+    segmentFilter: 'no-uploads',
+    scheduledAt: null,
+  };
+
+  scheduleDate = '';
+  testEmail = '';
+  confirmCancelId: string | null = null;
+
+  isLoading = false;
+  isSaving = false;
+  error: string | null = null;
+  success: string | null = null;
+
+  readonly segmentOptions = [
+    { value: 'no-uploads', label: 'No Uploads — verified, never uploaded' },
+    { value: 'stuck-under-minimum', label: 'Stuck Under Minimum — 1-4 uploads' },
+    { value: 'has-uploads-no-model', label: 'Has Uploads, No Model — 5+ uploads, not trained' },
+    { value: 'inactive-30d', label: 'Inactive 30d — has uploads, no activity' },
+    { value: 'all-verified', label: 'All Verified — everyone opted in' },
+  ];
+
+  private destroy$ = new Subject<void>();
+
+  constructor(private _marketing: MarketingService) {}
+
+  ngOnInit(): void {
+    this.loadCampaigns();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  // ── LIST ───────────────────────────────────────────────────────────────────
+
+  loadCampaigns(): void {
+    this.isLoading = true;
+    this.error = null;
+    this._marketing
+      .getCampaigns(this.page, this.pageSize)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: res => {
+          this.campaigns = res.campaigns;
+          this.totalCount = res.totalCount;
+          this.isLoading = false;
+        },
+        error: () => {
+          this.error = 'Failed to load campaigns.';
+          this.isLoading = false;
+        },
+      });
+  }
+
+  // ── CREATE ─────────────────────────────────────────────────────────────────
+
+  showCreate(): void {
+    this.view = 'create';
+    this.model = {
+      name: '',
+      subject: 'Good news: you can now create AI headshots with just 5 photos',
+      htmlBody: FIRST_CAMPAIGN_BODY,
+      segmentFilter: 'no-uploads',
+      scheduledAt: null,
+    };
+    this.segmentCount = null;
+    this.error = null;
+    this.success = null;
+  }
+
+  previewSegmentCount(): void {
+    if (!this.model.segmentFilter) {return;}
+    this.segmentCounting = true;
+    this._marketing
+      .previewSegment(this.model.segmentFilter)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: res => {
+          this.segmentCount = res.count;
+          this.segmentCounting = false;
+        },
+        error: () => {
+          this.segmentCounting = false;
+        },
+      });
+  }
+
+  createCampaign(): void {
+    if (!this.model.name || !this.model.subject || !this.model.htmlBody) {
+      this.error = 'Name, subject, and body are required.';
+      return;
+    }
+    this.isSaving = true;
+    this.error = null;
+    const payload = {
+      ...this.model,
+      scheduledAt: this.model.scheduledAt || null,
+    };
+    this._marketing
+      .createCampaign(payload)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: campaign => {
+          this.isSaving = false;
+          this.view = 'list';
+          this.loadCampaigns();
+          this.success = `Campaign "${campaign.name}" created.`;
+        },
+        error: err => {
+          this.error = err?.error?.error?.message || 'Failed to create campaign.';
+          this.isSaving = false;
+        },
+      });
+  }
+
+  // ── DETAIL ─────────────────────────────────────────────────────────────────
+
+  openDetail(id: string): void {
+    this.isLoading = true;
+    this.error = null;
+    this._marketing
+      .getCampaign(id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: c => {
+          this.selectedCampaign = c;
+          this.scheduleDate = c.scheduledAt ? c.scheduledAt.slice(0, 16) : '';
+          this.view = 'detail';
+          this.isLoading = false;
+        },
+        error: () => {
+          this.error = 'Failed to load campaign.';
+          this.isLoading = false;
+        },
+      });
+  }
+
+  scheduleCampaign(): void {
+    if (!this.selectedCampaign || !this.scheduleDate) {return;}
+    this.isSaving = true;
+    this._marketing
+      .scheduleCampaign(this.selectedCampaign.id, new Date(this.scheduleDate).toISOString())
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.success = 'Campaign scheduled.';
+          this.isSaving = false;
+          this.openDetail(this.selectedCampaign!.id);
+        },
+        error: err => {
+          this.error = err?.error?.error?.message || 'Failed to schedule.';
+          this.isSaving = false;
+        },
+      });
+  }
+
+  cancelCampaign(id: string): void {
+    this._marketing
+      .cancelCampaign(id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.confirmCancelId = null;
+          this.success = 'Campaign cancelled.';
+          if (this.view === 'detail') {this.openDetail(id);}
+          else {this.loadCampaigns();}
+        },
+        error: err => {
+          this.error = err?.error?.error?.message || 'Failed to cancel.';
+          this.confirmCancelId = null;
+        },
+      });
+  }
+
+  duplicateCampaign(id: string): void {
+    this._marketing
+      .duplicateCampaign(id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: copy => {
+          this.success = `Duplicated as "${copy.name}".`;
+          this.loadCampaigns();
+          this.view = 'list';
+        },
+        error: () => {
+          this.error = 'Failed to duplicate campaign.';
+        },
+      });
+  }
+
+  sendTest(): void {
+    if (!this.selectedCampaign || !this.testEmail) {return;}
+    this.isSaving = true;
+    this._marketing
+      .sendTest(this.selectedCampaign.id, this.testEmail)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.success = `Test email sent to ${this.testEmail}.`;
+          this.isSaving = false;
+        },
+        error: err => {
+          this.error = err?.error?.error?.message || 'Failed to send test.';
+          this.isSaving = false;
+        },
+      });
+  }
+
+  openPreview(id: string): void {
+    window.open(this._marketing.getPreviewUrl(id), '_blank');
+  }
+
+  // ── LOGS ───────────────────────────────────────────────────────────────────
+
+  openLogs(id: string): void {
+    this.isLoading = true;
+    this.logPage = 1;
+    this._marketing
+      .getLogs(id, this.logPage)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: res => {
+          this.logs = res.logs;
+          this.logTotal = res.totalCount;
+          this.view = 'logs';
+          this.isLoading = false;
+        },
+        error: () => {
+          this.error = 'Failed to load logs.';
+          this.isLoading = false;
+        },
+      });
+  }
+
+  // ── HELPERS ────────────────────────────────────────────────────────────────
+
+  backToList(): void {
+    this.view = 'list';
+    this.selectedCampaign = null;
+    this.error = null;
+    this.success = null;
+    this.loadCampaigns();
+  }
+
+  get totalPages(): number {
+    return Math.ceil(this.totalCount / this.pageSize);
+  }
+
+  prevPage(): void {
+    if (this.page > 1) {
+      this.page--;
+      this.loadCampaigns();
+    }
+  }
+
+  nextPage(): void {
+    if (this.page < this.totalPages) {
+      this.page++;
+      this.loadCampaigns();
+    }
+  }
+
+  statusPillClass(status: string): string {
+    return (
+      {
+        Draft: '',
+        Scheduled: 'pill-credit',
+        Sending: 'pill-warning',
+        Sent: 'pill-success',
+        Cancelled: 'pill-danger',
+      }[status] ?? ''
+    );
+  }
+
+  logStatusPillClass(status: string): string {
+    return (
+      {
+        Sent: 'pill-success',
+        Failed: 'pill-danger',
+        Bounced: 'pill-danger',
+        Unsubscribed: 'pill-warning',
+        Pending: '',
+      }[status] ?? ''
+    );
+  }
+
+  canSchedule(campaign: CampaignDetailDto | null): boolean {
+    return campaign?.status === 'Draft' || campaign?.status === 'Cancelled';
+  }
+
+  canCancel(status: string): boolean {
+    return status === 'Draft' || status === 'Scheduled';
+  }
+}

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-coupons/admin-coupons.component.html
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-coupons/admin-coupons.component.html
@@ -12,6 +12,7 @@
     <a routerLink="/admin/users" routerLinkActive="is-active">Users</a>
     <a routerLink="/admin/coupons" routerLinkActive="is-active">Coupons</a>
     <a routerLink="/admin/audit-log" routerLinkActive="is-active">Audit Log</a>
+    <a routerLink="/admin/campaigns" routerLinkActive="is-active">Campaigns</a>
   </nav>
 
   <section class="admin-panel">

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-dashboard/admin-dashboard.component.html
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-dashboard/admin-dashboard.component.html
@@ -12,6 +12,7 @@
     <a routerLink="/admin/users" routerLinkActive="is-active">Users</a>
     <a routerLink="/admin/coupons" routerLinkActive="is-active">Coupons</a>
     <a routerLink="/admin/audit-log" routerLinkActive="is-active">Audit Log</a>
+    <a routerLink="/admin/campaigns" routerLinkActive="is-active">Campaigns</a>
   </nav>
 
   <!-- Loading State -->
@@ -61,6 +62,10 @@
     <a routerLink="/admin/audit-log" class="action-card">
       <h3>Audit Log</h3>
       <p>Review every admin action with timestamped change details.</p>
+    </a>
+    <a routerLink="/admin/campaigns" class="action-card">
+      <h3>Email Campaigns</h3>
+      <p>Create, schedule, and track targeted marketing emails by user segment.</p>
     </a>
   </section>
 </section>

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-user-detail/admin-user-detail.component.html
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-user-detail/admin-user-detail.component.html
@@ -15,6 +15,7 @@
     <a routerLink="/admin/users" routerLinkActive="is-active" [routerLinkActiveOptions]="{ exact: false }">Users</a>
     <a routerLink="/admin/coupons" routerLinkActive="is-active">Coupons</a>
     <a routerLink="/admin/audit-log" routerLinkActive="is-active">Audit Log</a>
+    <a routerLink="/admin/campaigns" routerLinkActive="is-active">Campaigns</a>
   </nav>
 
   <div *ngIf="isLoading" class="empty-state">

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-users/admin-users.component.html
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-users/admin-users.component.html
@@ -12,6 +12,7 @@
     <a routerLink="/admin/users" routerLinkActive="is-active">Users</a>
     <a routerLink="/admin/coupons" routerLinkActive="is-active">Coupons</a>
     <a routerLink="/admin/audit-log" routerLinkActive="is-active">Audit Log</a>
+    <a routerLink="/admin/campaigns" routerLinkActive="is-active">Campaigns</a>
   </nav>
 
   <section class="admin-panel">

--- a/AI.ProfilePhotoMaker.UI/src/app/app.routes.ts
+++ b/AI.ProfilePhotoMaker.UI/src/app/app.routes.ts
@@ -570,7 +570,24 @@ export const routes: Routes = [
           ),
         title: 'Audit Log',
       },
+      {
+        path: 'campaigns',
+        loadComponent: () =>
+          import('./admin/admin-campaigns/admin-campaigns.component').then(
+            m => m.AdminCampaignsComponent
+          ),
+        title: 'Email Campaigns',
+      },
     ],
+  },
+
+  // Unsubscribe page (linked from marketing emails)
+  {
+    path: 'unsubscribe',
+    loadComponent: () =>
+      import('./pages/unsubscribe/unsubscribe.component').then(m => m.UnsubscribeComponent),
+    title: 'Unsubscribe - AI Profile Photo Maker',
+    data: { hideNavigation: true },
   },
 
   // 404 and Wildcard - Must be last

--- a/AI.ProfilePhotoMaker.UI/src/app/pages/unsubscribe/unsubscribe.component.html
+++ b/AI.ProfilePhotoMaker.UI/src/app/pages/unsubscribe/unsubscribe.component.html
@@ -1,0 +1,38 @@
+<div class="unsub-shell">
+  <div class="unsub-card">
+    <div class="unsub-brand">AI Profile Photo Maker</div>
+
+    <ng-container [ngSwitch]="state">
+      <div *ngSwitchCase="'loading'" class="unsub-body loading-state">
+        <p>Processing your request…</p>
+      </div>
+
+      <div *ngSwitchCase="'success'" class="unsub-body">
+        <div class="unsub-icon success-icon">✓</div>
+        <h1>You've been unsubscribed</h1>
+        <p>
+          We've removed you from our marketing emails. You'll still receive important account emails like receipts and
+          security alerts.
+        </p>
+        <a routerLink="/" class="unsub-cta">Back to home</a>
+      </div>
+
+      <div *ngSwitchCase="'invalid'" class="unsub-body">
+        <div class="unsub-icon error-icon">!</div>
+        <h1>Invalid link</h1>
+        <p>
+          This unsubscribe link is missing or malformed. If you'd like to opt out, you can update your preferences from
+          your account settings.
+        </p>
+        <a routerLink="/" class="unsub-cta">Go home</a>
+      </div>
+
+      <div *ngSwitchCase="'error'" class="unsub-body">
+        <div class="unsub-icon error-icon">!</div>
+        <h1>Something went wrong</h1>
+        <p>We couldn't process your request. Please try again or contact support if the issue persists.</p>
+        <a routerLink="/" class="unsub-cta">Go home</a>
+      </div>
+    </ng-container>
+  </div>
+</div>

--- a/AI.ProfilePhotoMaker.UI/src/app/pages/unsubscribe/unsubscribe.component.sass
+++ b/AI.ProfilePhotoMaker.UI/src/app/pages/unsubscribe/unsubscribe.component.sass
@@ -1,0 +1,75 @@
+.unsub-shell
+  min-height: 100vh
+  display: flex
+  align-items: center
+  justify-content: center
+  padding: 2rem 1rem
+  background: radial-gradient(circle at 30% 20%, rgba(14, 165, 233, 0.08), transparent 50%), var(--bg-primary)
+
+.unsub-card
+  width: 100%
+  max-width: 480px
+  background: var(--card-bg)
+  border: 1px solid var(--border-color)
+  border-radius: 20px
+  padding: 2.5rem 2rem
+  text-align: center
+  box-shadow: var(--shadow-md)
+
+.unsub-brand
+  font-size: 0.8rem
+  font-weight: 700
+  text-transform: uppercase
+  letter-spacing: 0.14em
+  color: var(--accent-primary)
+  margin-bottom: 2rem
+
+.unsub-body
+  display: flex
+  flex-direction: column
+  align-items: center
+  gap: 1rem
+
+  h1
+    margin: 0
+    font-size: 1.6rem
+    line-height: 1.2
+
+  p
+    margin: 0
+    color: var(--text-secondary)
+    line-height: 1.6
+    max-width: 340px
+
+.unsub-icon
+  width: 56px
+  height: 56px
+  border-radius: 50%
+  display: flex
+  align-items: center
+  justify-content: center
+  font-size: 1.6rem
+  font-weight: 700
+
+.success-icon
+  background: color-mix(in srgb, var(--accent-success) 18%, transparent)
+  color: var(--accent-success)
+
+.error-icon
+  background: color-mix(in srgb, var(--accent-warning) 18%, transparent)
+  color: var(--accent-warning)
+
+.loading-state
+  color: var(--text-tertiary)
+
+.unsub-cta
+  display: inline-block
+  margin-top: 0.5rem
+  padding: 0.65rem 1.5rem
+  border-radius: 10px
+  background: linear-gradient(120deg, color-mix(in srgb, var(--accent-primary) 40%, transparent), color-mix(in srgb, var(--accent-secondary) 36%, transparent))
+  color: var(--text-primary)
+  font-weight: 700
+  text-decoration: none
+  font-size: 0.9rem
+  border: 1px solid var(--border-color)

--- a/AI.ProfilePhotoMaker.UI/src/app/pages/unsubscribe/unsubscribe.component.ts
+++ b/AI.ProfilePhotoMaker.UI/src/app/pages/unsubscribe/unsubscribe.component.ts
@@ -1,0 +1,38 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { MarketingService } from '../../services/marketing.service';
+
+type State = 'loading' | 'success' | 'error' | 'invalid';
+
+@Component({
+  selector: 'app-unsubscribe',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './unsubscribe.component.html',
+  styleUrls: ['./unsubscribe.component.sass'],
+})
+export class UnsubscribeComponent implements OnInit {
+  state: State = 'loading';
+
+  constructor(
+    private _route: ActivatedRoute,
+    private _marketing: MarketingService
+  ) {}
+
+  ngOnInit(): void {
+    const token = this._route.snapshot.queryParamMap.get('token');
+    if (!token) {
+      this.state = 'invalid';
+      return;
+    }
+    this._marketing.unsubscribe(token).subscribe({
+      next: () => {
+        this.state = 'success';
+      },
+      error: () => {
+        this.state = 'error';
+      },
+    });
+  }
+}

--- a/AI.ProfilePhotoMaker.UI/src/app/services/marketing.service.ts
+++ b/AI.ProfilePhotoMaker.UI/src/app/services/marketing.service.ts
@@ -1,0 +1,151 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { BaseHttpService } from './base-http.service';
+import { ConfigService } from './config.service';
+
+export interface CampaignDto {
+  id: string;
+  name: string;
+  subject: string;
+  segmentFilter: string;
+  scheduledAt: string | null;
+  status: 'Draft' | 'Scheduled' | 'Sending' | 'Sent' | 'Cancelled';
+  recipientCount: number;
+  sentCount: number;
+  failedCount: number;
+  createdBy: string | null;
+  createdAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+export interface CampaignDetailDto extends CampaignDto {
+  htmlBody: string;
+}
+
+export interface EmailLogDto {
+  id: string;
+  userId: string;
+  email: string;
+  status: string;
+  errorMessage: string | null;
+  sentAt: string | null;
+  createdAt: string;
+}
+
+export interface CreateCampaignRequest {
+  name: string;
+  subject: string;
+  htmlBody: string;
+  segmentFilter: string;
+  scheduledAt?: string | null;
+}
+
+export interface UpdateCampaignRequest {
+  name?: string;
+  subject?: string;
+  htmlBody?: string;
+  segmentFilter?: string;
+}
+
+export interface CampaignListResult {
+  campaigns: CampaignDto[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+export interface LogListResult {
+  logs: EmailLogDto[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class MarketingService extends BaseHttpService {
+  constructor(
+    protected override http: HttpClient,
+    protected override config: ConfigService
+  ) {
+    super(http, config);
+  }
+
+  getCampaigns(page = 1, pageSize = 20): Observable<CampaignListResult> {
+    return this.get<CampaignListResult>(`admin/campaigns?page=${page}&pageSize=${pageSize}`, {
+      withCredentials: true,
+    });
+  }
+
+  getCampaign(id: string): Observable<CampaignDetailDto> {
+    return this.get<CampaignDetailDto>(`admin/campaigns/${id}`, { withCredentials: true });
+  }
+
+  createCampaign(req: CreateCampaignRequest): Observable<CampaignDetailDto> {
+    return this.post<CampaignDetailDto>('admin/campaigns', req, { withCredentials: true });
+  }
+
+  updateCampaign(id: string, req: UpdateCampaignRequest): Observable<CampaignDetailDto> {
+    return this.http.patch<CampaignDetailDto>(this.buildApiUrl(`admin/campaigns/${id}`), req, {
+      withCredentials: true,
+    });
+  }
+
+  scheduleCampaign(id: string, scheduledAt: string): Observable<{ scheduled: boolean }> {
+    return this.post<{ scheduled: boolean }>(
+      `admin/campaigns/${id}/schedule`,
+      { scheduledAt },
+      { withCredentials: true }
+    );
+  }
+
+  cancelCampaign(id: string): Observable<{ cancelled: boolean }> {
+    return this.post<{ cancelled: boolean }>(
+      `admin/campaigns/${id}/cancel`,
+      {},
+      { withCredentials: true }
+    );
+  }
+
+  sendTest(id: string, testEmail: string): Observable<{ sent: boolean }> {
+    return this.post<{ sent: boolean }>(
+      `admin/campaigns/${id}/test`,
+      { testEmail },
+      { withCredentials: true }
+    );
+  }
+
+  duplicateCampaign(id: string): Observable<CampaignDetailDto> {
+    return this.post<CampaignDetailDto>(
+      `admin/campaigns/${id}/duplicate`,
+      {},
+      { withCredentials: true }
+    );
+  }
+
+  getLogs(id: string, page = 1, pageSize = 50): Observable<LogListResult> {
+    return this.get<LogListResult>(`admin/campaigns/${id}/logs?page=${page}&pageSize=${pageSize}`, {
+      withCredentials: true,
+    });
+  }
+
+  previewSegment(segmentFilter: string): Observable<{ segmentFilter: string; count: number }> {
+    return this.post<{ segmentFilter: string; count: number }>(
+      'admin/campaigns/segments/preview',
+      { segmentFilter },
+      { withCredentials: true }
+    );
+  }
+
+  getPreviewUrl(id: string): string {
+    return this.buildApiUrl(`admin/campaigns/${id}/preview`);
+  }
+
+  unsubscribe(token: string): Observable<{ unsubscribed: boolean }> {
+    return this.post<{ unsubscribed: boolean }>(
+      `user/marketing/unsubscribe?token=${encodeURIComponent(token)}`,
+      {}
+    );
+  }
+}

--- a/docs/features/marketing-email-service-spec.md
+++ b/docs/features/marketing-email-service-spec.md
@@ -1,0 +1,264 @@
+# Marketing Email Service — Feature Specification
+
+## Overview
+Build a scheduled marketing email system that supports targeted user segments, campaign management, and bulk email delivery with tracking. This enables re-engagement campaigns, feature announcements, and lifecycle marketing without building one-off blasts.
+
+## Goals
+- Send scheduled marketing emails to targeted user segments
+- Prevent duplicate sends via recipient tracking
+- Provide admin endpoints for campaign creation/management
+- Support unsubscribe/opt-out functionality
+- Use existing email design system (dark navy wrapper, white card, sky blue CTA)
+
+## First Campaign
+**"You now only need 5 selfies"** — notify users who signed up but never uploaded (or uploaded < 10 photos) that the barrier to entry is now lower.
+
+---
+
+## Data Models
+
+### MarketingCampaign
+```csharp
+public class MarketingCampaign
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;              // Internal name
+    public string Subject { get; set; } = null!;           // Email subject line
+    public string HtmlBody { get; set; } = null!;          // Email body (pre-wrapped)
+    public string SegmentFilter { get; set; } = null!;     // no-uploads | stuck-under-minimum | inactive-30d | has-uploads-no-model | all-verified
+    public DateTime? ScheduledAt { get; set; }            // When to send (null = draft)
+    public CampaignStatus Status { get; set; }              // Draft | Scheduled | Sending | Sent | Cancelled
+    public int RecipientCount { get; set; }                 // Target count at send time
+    public int SentCount { get; set; }                      // Actually sent
+    public int FailedCount { get; set; }                    // Failed sends
+    public string? CreatedBy { get; set; }                  // Admin user ID
+    public DateTime CreatedAt { get; set; }
+    public DateTime? StartedAt { get; set; }
+    public DateTime? CompletedAt { get; set; }
+}
+
+public enum CampaignStatus { Draft, Scheduled, Sending, Sent, Cancelled }
+```
+
+### MarketingEmailLog
+```csharp
+public class MarketingEmailLog
+{
+    public Guid Id { get; set; }
+    public Guid CampaignId { get; set; }
+    public string UserId { get; set; } = null!;
+    public string Email { get; set; } = null!;
+    public EmailStatus Status { get; set; }              // Pending | Sent | Failed | Bounced | Unsubscribed
+    public string? ErrorMessage { get; set; }
+    public DateTime? SentAt { get; set; }
+    public DateTime CreatedAt { get; set; }
+}
+
+public enum EmailStatus { Pending, Sent, Failed, Bounced, Unsubscribed }
+```
+
+### UserProfile Update
+```csharp
+public class ApplicationUser
+{
+    // Add to existing:
+    public bool MarketingOptOut { get; set; }              // Unsubscribe flag
+    public DateTime? MarketingOptOutAt { get; set; }
+}
+```
+
+---
+
+## User Segments
+
+| Segment | Filter Logic |
+|---------|-------------|
+| `no-uploads` | Signed up, email verified, 0 photos uploaded |
+| `stuck-under-minimum` | Uploaded 1-4 photos (previously blocked at 10, now can train) |
+| `has-uploads-no-model` | Uploaded 5+ photos, never started training |
+| `inactive-30d` | No login in last 30 days, has uploads |
+| `all-verified` | All users with verified email, not opted out |
+
+---
+
+## API Endpoints
+
+### Admin Endpoints
+
+```
+POST   /api/admin/campaigns                    → Create campaign (draft)
+GET    /api/admin/campaigns                    → List all campaigns
+GET    /api/admin/campaigns/{id}               → Get campaign details + stats
+PATCH  /api/admin/campaigns/{id}               → Update campaign (only if Draft)
+POST   /api/admin/campaigns/{id}/schedule    → Schedule send (sets ScheduledAt, validates)
+POST   /api/admin/campaigns/{id}/cancel        → Cancel scheduled campaign
+POST   /api/admin/campaigns/{id}/test          → Send test to admin email only
+GET    /api/admin/campaigns/{id}/recipients   → Preview recipient list (paginated)
+GET    /api/admin/campaigns/{id}/logs          → Email delivery logs (paginated)
+POST   /api/admin/campaigns/{id}/duplicate    → Clone campaign as new draft
+
+POST   /api/admin/segments/preview             → Preview user count for segment filter
+```
+
+### User Endpoints
+
+```
+POST /api/user/marketing/unsubscribe            → Unsubscribe from marketing (link in email)
+GET  /api/user/marketing/status                → Check opt-in status
+```
+
+### Request/Response Schemas
+
+**Create Campaign:**
+```json
+{
+  "name": "5 Image Minimum Launch",
+  "subject": "Good news: You can now create headshots with just 5 selfies",
+  "htmlBody": "<p>We heard your feedback...</p>",
+  "segmentFilter": "no-uploads",
+  "scheduledAt": "2026-04-10T09:00:00Z"
+}
+```
+
+---
+
+## Services
+
+### IUserSegmentService
+```csharp
+public interface IUserSegmentService
+{
+    Task<int> GetSegmentCountAsync(string segmentFilter);
+    Task<IEnumerable<string>> GetSegmentUserIdsAsync(string segmentFilter, int page, int pageSize);
+    Task<bool> IsUserInSegmentAsync(string userId, string segmentFilter);
+}
+```
+
+### IMarketingEmailService
+```csharp
+public interface IMarketingEmailService
+{
+    Task<MarketingCampaign> CreateCampaignAsync(CreateCampaignRequest request, string createdBy);
+    Task ScheduleCampaignAsync(Guid campaignId, DateTime scheduledAt);
+    Task CancelCampaignAsync(Guid campaignId);
+    Task SendTestAsync(Guid campaignId, string testEmail);
+    Task ExecuteCampaignAsync(Guid campaignId);  // Called by background job
+}
+```
+
+### MarketingEmailBackgroundService
+```csharp
+public class MarketingEmailBackgroundService : BackgroundService
+{
+    // Runs every minute
+    // Finds campaigns with Status=Scheduled and ScheduledAt <= Now
+    // Updates status to Sending, processes in batches
+    // Respects Postmark rate limits (e.g., 100/sec for burst, 10/sec sustained)
+}
+```
+
+---
+
+## Email Template
+
+Uses existing `WrapEmail()` layout. Adds unsubscribe footer:
+
+```html
+<p style="margin:24px 0 0; font-size:13px; color:#64748b;">
+  You're receiving this because you signed up for AI Profile Photo Maker.
+  <a href="{unsubscribeUrl}" style="color:#64748b; text-decoration:underline;">Unsubscribe</a> from marketing emails.
+</p>
+```
+
+---
+
+## Database Migrations
+
+```sql
+-- MarketingCampaigns table
+CREATE TABLE MarketingCampaigns (
+    Id UNIQUEIDENTIFIER PRIMARY KEY,
+    Name NVARCHAR(200) NOT NULL,
+    Subject NVARCHAR(300) NOT NULL,
+    HtmlBody NVARCHAR(MAX) NOT NULL,
+    SegmentFilter NVARCHAR(50) NOT NULL,
+    ScheduledAt DATETIME2 NULL,
+    Status INT NOT NULL,
+    RecipientCount INT NOT NULL DEFAULT 0,
+    SentCount INT NOT NULL DEFAULT 0,
+    FailedCount INT NOT NULL DEFAULT 0,
+    CreatedBy NVARCHAR(450) NULL,
+    CreatedAt DATETIME2 NOT NULL,
+    StartedAt DATETIME2 NULL,
+    CompletedAt DATETIME2 NULL
+);
+
+-- MarketingEmailLogs table
+CREATE TABLE MarketingEmailLogs (
+    Id UNIQUEIDENTIFIER PRIMARY KEY,
+    CampaignId UNIQUEIDENTIFIER NOT NULL,
+    UserId NVARCHAR(450) NOT NULL,
+    Email NVARCHAR(256) NOT NULL,
+    Status INT NOT NULL,
+    ErrorMessage NVARCHAR(MAX) NULL,
+    SentAt DATETIME2 NULL,
+    CreatedAt DATETIME2 NOT NULL,
+    CONSTRAINT FK_Logs_Campaign FOREIGN KEY (CampaignId) REFERENCES MarketingCampaigns(Id)
+);
+CREATE INDEX IX_MarketingEmailLogs_CampaignId ON MarketingEmailLogs(CampaignId);
+CREATE INDEX IX_MarketingEmailLogs_UserId ON MarketingEmailLogs(UserId);
+CREATE INDEX IX_MarketingEmailLogs_Status ON MarketingEmailLogs(Status);
+
+-- Add columns to AspNetUsers
+ALTER TABLE AspNetUsers ADD MarketingOptOut BIT NOT NULL DEFAULT 0;
+ALTER TABLE AspNetUsers ADD MarketingOptOutAt DATETIME2 NULL;
+```
+
+---
+
+## Implementation Plan
+
+| Step | Action | Est | PR |
+|------|--------|-----|-----|
+| 1 | Create spec document (this file) | 30 min | — |
+| 2 | Add EF entities + migrations | 45 min | #351 |
+| 3 | Build `IUserSegmentService` + implementations | 1 hr | #352 |
+| 4 | Build `IMarketingEmailService` + Postmark integration | 1.5 hr | #353 |
+| 5 | Add admin API endpoints (CRUD + schedule/test) | 1.5 hr | #354 |
+| 6 | Build `MarketingEmailBackgroundService` | 1 hr | #355 |
+| 7 | Add unsubscribe endpoint + email footer | 30 min | #356 |
+| 8 | Create first campaign content + send test | 30 min | — |
+| 9 | End-to-end testing + deploy | 1 hr | — |
+
+**Total estimate:** ~8 hours across ~6 PRs
+
+---
+
+## Open Questions
+
+1. **Rate limiting:** Postmark allows 100/sec burst, 10/sec sustained. Should we configure per-campaign batch sizes, or hardcode sensible defaults?
+2. **Admin auth:** Should campaigns be restricted to a specific admin role, or any authenticated admin user?
+3. **Email preview:** Do we want a "preview" endpoint that returns the fully-rendered email HTML for review before sending?
+4. **Bounce handling:** Should we auto-unsubscribe users after N bounces, or just log and continue?
+5. **Throttling:** Should we spread large campaigns over multiple hours to avoid spam filters, or send in one batch?
+
+---
+
+## Success Criteria
+
+- [ ] Admin can create a campaign and preview recipient count
+- [ ] Admin can schedule a campaign for future delivery
+- [ ] Admin can send a test email to verify content
+- [ ] Background service picks up scheduled campaigns and sends them
+- [ ] Each recipient receives exactly one email (no duplicates)
+- [ ] Users can unsubscribe via footer link
+- [ ] Unsubscribed users are excluded from future campaigns
+- [ ] Delivery stats (sent/failed) are visible in admin UI
+- [ ] First campaign sent to `no-uploads` + `stuck-under-minimum` segments
+
+---
+
+## Related Documents
+
+- [min-images-5-spec.md](./min-images-5-spec.md) — Previous feature that motivated this campaign
+- [EmailNotificationService.cs](../../AI.ProfilePhotoMaker.API/Services/Notifications/EmailNotificationService.cs) — Existing email template


### PR DESCRIPTION
## Summary

- Full end-to-end marketing email system: campaign CRUD, scheduling, bulk delivery, bounce/unsubscribe handling
- 5 user segments for targeting (no-uploads, stuck-under-minimum, has-uploads-no-model, inactive-30d, all-verified)
- Admin UI at `/admin/campaigns` for creating, scheduling, previewing, and monitoring campaigns
- Postmark webhook auto-unsubscribes users on hard bounce or spam complaint
- First campaign content ready: "5 selfie minimum" re-engagement email for `no-uploads` + `stuck-under-minimum` users

## Key files

| Layer | Files |
|-------|-------|
| Models | `MarketingCampaign`, `MarketingEmailLog`, `ApplicationUser` (+opt-out fields) |
| Services | `MarketingEmailService`, `UserSegmentService`, `MarketingEmailBackgroundService`, `FirstCampaignContent` |
| Controllers | `MarketingCampaignController`, `MarketingUnsubscribeController`, `PostmarkWebhookController` |
| Frontend | `AdminCampaignsComponent`, `UnsubscribeComponent`, `MarketingService` |
| Migration | `20260408121713_AddMarketingEmailService` |

## Test plan

- [ ] Deploy and run `dotnet ef database update` to apply migration
- [ ] Navigate to `/admin/campaigns`, create a campaign using the first-campaign defaults
- [ ] Use "Count recipients" on `no-uploads` segment — verify a non-zero count
- [ ] Send a test email to yourself — verify it arrives with correct formatting and unsubscribe link
- [ ] Click unsubscribe link — verify `/unsubscribe` page shows success and `MarketingOptOut` is set in DB
- [ ] Schedule campaign for 2 minutes in the future — verify background service picks it up and sends
- [ ] Check delivery logs via the Logs view
- [ ] Configure Postmark webhook to `POST /api/webhooks/postmark` with `Authorization: Bearer {PostmarkWebhookSecret}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)