### PR TITLE
fix: use 10.0-preview Docker tags for .NET 10 preview

### DIFF
--- a/AI.ProfilePhotoMaker.API/Dockerfile
+++ b/AI.ProfilePhotoMaker.API/Dockerfile
@@ -1,9 +1,9 @@
 # Simple .NET 10 API Dockerfile
-FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-preview AS base
 WORKDIR /app
 EXPOSE 8080
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-preview AS build
 WORKDIR /src
 COPY ["AI.ProfilePhotoMaker.API.csproj", "."]
 RUN dotnet restore "AI.ProfilePhotoMaker.API.csproj"

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,9 +1,9 @@
 # Multi-stage build for .NET 10 API
-FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-preview AS base
 WORKDIR /app
 EXPOSE 8080
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-preview AS build
 WORKDIR /src
 
 # Copy project files


### PR DESCRIPTION
## Summary
- Fixed `Dockerfile.backend` and `AI.ProfilePhotoMaker.API/Dockerfile` to use `10.0-preview` image tags
- MCR returns 403 Forbidden for the bare `10.0` tag while .NET 10 is still in preview
- This was causing the Simple Deploy pipeline to fail on docker build

## Test plan
- [ ] CI deploy pipeline passes (docker build succeeds with `10.0-preview` tags)
- [ ] Container starts and health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)