### PR TITLE
fix: allow prerelease SDK in global.json for Docker compat

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.201",
+    "version": "10.0.100",
+    "allowPrerelease": true,
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Summary
- Lowered `global.json` SDK version from `10.0.201` to `10.0.100` and added `allowPrerelease: true`
- The `10.0-preview` Docker images ship SDK `10.0.100-preview.7`, which couldn't satisfy `10.0.201`
- With `latestFeature` roll-forward, local dev uses `10.0.201` (GA) and Docker uses `10.0.100-preview.7`

## Test plan
- [ ] CI Simple Deploy pipeline passes (docker build succeeds)
- [ ] Local `dotnet build` still resolves to 10.0.201

🤖 Generated with [Claude Code](https://claude.com/claude-code)