### PR TITLE
fix: pin global.json to preview SDK for Docker build

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
-    "allowPrerelease": true,
+    "version": "10.0.100-preview.7",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Summary
- Changed `global.json` version from `10.0.100` to `10.0.100-preview.7`
- The `10.0-preview` Docker SDK image ships `10.0.100-preview.7` which is semver-lower than `10.0.100` release — no roll-forward policy can bridge that gap
- `latestFeature` still selects `10.0.201` for local development

## Test plan
- [ ] CI Simple Deploy pipeline passes end-to-end
- [ ] Local `dotnet --version` resolves to 10.0.201

🤖 Generated with [Claude Code](https://claude.com/claude-code)