### PR TITLE
fix: use KnownNetworks for preview SDK compat

### DIFF
--- a/AI.ProfilePhotoMaker.API/Program.cs
+++ b/AI.ProfilePhotoMaker.API/Program.cs
@@ -126,7 +126,9 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
     options.ForwardedHeaders = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor |
                               Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto |
                               Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedHost;
-    options.KnownIPNetworks.Clear();
+#pragma warning disable ASPDEPR005 // KnownNetworks renamed to KnownIPNetworks in GA; preview SDK lacks the new name
+    options.KnownNetworks.Clear();
+#pragma warning restore ASPDEPR005
     options.KnownProxies.Clear();
 
     // Restrict forwarded host values to known application hosts to prevent host header injection.


### PR DESCRIPTION
## Summary
- `KnownIPNetworks` was renamed from `KnownNetworks` in .NET 10 GA, but the `10.0-preview` Docker image only has the old name
- Reverted to `KnownNetworks` with `#pragma warning disable ASPDEPR005` to suppress the obsolete warning in GA
- Compiles clean on both preview SDK (Docker) and GA SDK (local)

## Test plan
- [ ] CI deploy pipeline builds Docker image successfully
- [ ] Application starts and forwarded headers work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)