### PR TITLE
Fix private blob upload container creation

### DIFF
--- a/AI.ProfilePhotoMaker.API.Tests/Unit/AzureBlobStorageServiceTests.cs
+++ b/AI.ProfilePhotoMaker.API.Tests/Unit/AzureBlobStorageServiceTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 using AI.ProfilePhotoMaker.API.Services.Storage;
 using AI.ProfilePhotoMaker.API.Services;
 using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
 
 namespace AI.ProfilePhotoMaker.API.Tests.Unit;
 
@@ -34,6 +35,26 @@ public class AzureBlobStorageServiceTests
         var blobClient = new BlobServiceClient("UseDevelopmentStorage=true");
 
         return new AzureBlobStorageService(blobClient, config, logger.Object);
+    }
+
+    [Fact]
+    public async Task EnsureContainerExistsAsync_UsesPrivateContainerAccess()
+    {
+        PublicAccessType? observedPublicAccessType = null;
+        var containerClient = new Mock<BlobContainerClient>();
+        containerClient
+            .Setup(client => client.CreateIfNotExistsAsync(
+                It.IsAny<PublicAccessType>(),
+                It.IsAny<IDictionary<string, string>>(),
+                It.IsAny<BlobContainerEncryptionScopeOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<PublicAccessType, IDictionary<string, string>, BlobContainerEncryptionScopeOptions, CancellationToken>((publicAccessType, _, _, _) =>
+                observedPublicAccessType = publicAccessType)
+            .ReturnsAsync((Azure.Response<BlobContainerInfo>?)null);
+
+        await AzureBlobStorageService.EnsureContainerExistsAsync(containerClient.Object);
+
+        Assert.Equal(PublicAccessType.None, observedPublicAccessType);
     }
 
     [Fact]

--- a/AI.ProfilePhotoMaker.API/AI.ProfilePhotoMaker.API.csproj
+++ b/AI.ProfilePhotoMaker.API/AI.ProfilePhotoMaker.API.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.9" />
     <PackageReference Include="tryAGI.Replicate" Version="1.0.3" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.22.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
     <PackageReference Include="Markdig" Version="0.39.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.5" />
@@ -40,7 +40,7 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="10.0.0" />
     <PackageReference Include="Azure.Identity" Version="1.14.2" />
-    <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.4.0" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AI.ProfilePhotoMaker.API/Services/Storage/AzureBlobStorageService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/Storage/AzureBlobStorageService.cs
@@ -22,6 +22,15 @@ public class AzureBlobStorageService : BaseStorageService
         _containerName = configuration["AzureStorage:ContainerName"] ?? "profile-images";
     }
 
+    internal static async Task EnsureContainerExistsAsync(BlobContainerClient containerClient, CancellationToken cancellationToken = default)
+    {
+        // Production storage accounts disable public blob access. Asking Azure to create a
+        // public container fails with PublicAccessNotPermitted before upload can start.
+        await containerClient.CreateIfNotExistsAsync(
+            publicAccessType: PublicAccessType.None,
+            cancellationToken: cancellationToken);
+    }
+
     public override async Task<string> SaveImageAsync(Stream imageStream, string fileName, string userId, string folderType = "generated")
     {
         ValidateUserId(userId);
@@ -30,7 +39,7 @@ public class AzureBlobStorageService : BaseStorageService
         try
         {
             var containerClient = _blobServiceClient.GetBlobContainerClient(_containerName);
-            await containerClient.CreateIfNotExistsAsync(PublicAccessType.Blob);
+            await EnsureContainerExistsAsync(containerClient);
 
             var blobPath = GenerateUserStoragePath(userId, fileName, folderType);
             var blobClient = containerClient.GetBlobClient(blobPath);
@@ -78,7 +87,7 @@ public class AzureBlobStorageService : BaseStorageService
             }
 
             var containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
-            await containerClient.CreateIfNotExistsAsync(PublicAccessType.Blob);
+            await EnsureContainerExistsAsync(containerClient);
 
             var blobClient = containerClient.GetBlobClient(blobPath.TrimStart('/'));
 
@@ -389,8 +398,8 @@ public class AzureBlobStorageService : BaseStorageService
             var containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
             var blobClient = containerClient.GetBlobClient(blobPath.TrimStart('/'));
 
-            // For Azurite/local development, the blob containers are configured as public (`PublicAccessType.Blob`).
-            // Returning a plain URL avoids SAS version incompatibilities (Azurite may reject newer `sv` values).
+            // For Azurite/local development, returning a plain URL avoids SAS version incompatibilities
+            // (Azurite may reject newer `sv` values). Browser delivery still goes through the API proxy.
             if (IsAzuriteEndpoint(_blobServiceClient.Uri))
             {
                 return Task.FromResult(blobClient.Uri.ToString());
@@ -512,7 +521,7 @@ public class AzureBlobStorageService : BaseStorageService
             }
 
             var containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
-            await containerClient.CreateIfNotExistsAsync(PublicAccessType.Blob);
+            await EnsureContainerExistsAsync(containerClient);
 
             var blobClient = containerClient.GetBlobClient(blobPath.TrimStart('/'));
 

--- a/infrastructure/simple-deploy.bicep
+++ b/infrastructure/simple-deploy.bicep
@@ -471,6 +471,10 @@ resource backendApp 'Microsoft.App/containerApps@2023-05-01' = {
               name: 'AzureStorage__ContainerName'
               value: 'profile-images'
             }
+            {
+              name: 'Storage__ProxyBlobRequests'
+              value: 'true'
+            }
             // Plain env vars for EnvironmentConfiguration production checks
             {
               name: 'AZURE_STORAGE_CONNECTION_STRING'

--- a/infrastructure/simple-deploy.json
+++ b/infrastructure/simple-deploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.36.177.2456",
-      "templateHash": "11391304353066336142"
+      "templateHash": "12689769709904259939"
     }
   },
   "parameters": {
@@ -568,6 +568,10 @@
                 {
                   "name": "AzureStorage__ContainerName",
                   "value": "profile-images"
+                },
+                {
+                  "name": "Storage__ProxyBlobRequests",
+                  "value": "true"
                 },
                 {
                   "name": "AZURE_STORAGE_CONNECTION_STRING",


### PR DESCRIPTION
## Summary
- create Azure blob containers without requesting public blob access
- add regression coverage for private container creation
- set Storage__ProxyBlobRequests=true in deployment template

## Production root cause
Production upload failed with Azure RequestFailedException `PublicAccessNotPermitted` after storage account public access was disabled. The upload path still called CreateIfNotExistsAsync(PublicAccessType.Blob).

## Verification
- dotnet test AI.ProfilePhotoMaker.API.Tests/AI.ProfilePhotoMaker.API.Tests.csproj --filter AzureBlobStorageServiceTests --no-restore
- dotnet test AI.ProfilePhotoMaker.API.Tests/AI.ProfilePhotoMaker.API.Tests.csproj --no-restore
- az bicep build --file infrastructure/simple-deploy.bicep
- git diff --check

## Rollback
Revert this PR, or temporarily re-enable account-level public blob access if emergency rollback is needed.