### PR TITLE
Allow proxy storage env in deploy validation

### DIFF
--- a/.github/workflows/simple-deploy.yml
+++ b/.github/workflows/simple-deploy.yml
@@ -561,7 +561,8 @@ jobs:
             echo "$BICEP_SIMILAR_VARS" | while read var; do
               # Valid Azure Storage configuration patterns - these are correct and should not be flagged as errors
               if [[ "$var" == "AZURE_STORAGE_CONNECTION_STRING" || "$var" == "AZURE_STORAGE_CONTAINER_NAME" || 
-                    "$var" == "ConnectionStrings__AzureStorage" || "$var" == "AzureStorage__ConnectionString" || "$var" == "AzureStorage__ContainerName" ]]; then
+                    "$var" == "ConnectionStrings__AzureStorage" || "$var" == "AzureStorage__ConnectionString" || "$var" == "AzureStorage__ContainerName" ||
+                    "$var" == "Storage__ProxyBlobRequests" ]]; then
                 echo "  ✅ $var (Correct Azure Storage configuration pattern)"
               else
                 echo "  ⚠️  $var (Potential mismatch - check if this should be AZURE_STORAGE_*)"


### PR DESCRIPTION
## Summary
- allow Storage__ProxyBlobRequests in the deployment storage-variable validator

## Why
The previous hotfix deployment failed because the validation script treated the proxy flag as a storage naming mismatch, even though ASP.NET Core maps it to Storage:ProxyBlobRequests.

## Verification
- git diff --check
- bash syntax check of extracted validation block