### PR TITLE
Add admin product health dashboard

### DIFF
--- a/AI.ProfilePhotoMaker.API.Tests/Services/AdminServiceTests.cs
+++ b/AI.ProfilePhotoMaker.API.Tests/Services/AdminServiceTests.cs
@@ -313,6 +313,55 @@ public class AdminServiceTests
     }
 
     [Fact]
+    public async Task GetProductHealthAsync_ReportsPivotMetricsAndUnavailableSignals()
+    {
+        using var context = CreateContext();
+        var userId = await SeedUserWithProfileAsync(context, credits: 0);
+        var profile = await context.UserProfiles.FirstAsync(p => p.UserId == userId);
+        var now = DateTime.UtcNow;
+
+        var starter = new OutcomePackageDefinition { Code = "starter", Name = "Starter Package", Price = 9m, Currency = "USD", IncludedCandidateCount = 3 };
+        var pro = new OutcomePackageDefinition { Code = "pro", Name = "Pro Package", Price = 19m, Currency = "USD", IncludedCandidateCount = 9 };
+        context.OutcomePackageDefinitions.AddRange(starter, pro);
+        await context.SaveChangesAsync();
+
+        context.ProcessedImages.AddRange(
+            new ProcessedImage { UserProfileId = profile.Id, OriginalImageUrl = "upload", ProcessedImageUrl = "upload", Style = "source", IsOriginalUpload = true, CreatedAt = now.AddDays(-1), ScheduledDeletionDate = now.AddDays(29) },
+            new ProcessedImage { UserProfileId = profile.Id, OriginalImageUrl = "o", ProcessedImageUrl = "openai", Style = "linkedin", IsGenerated = true, Provider = "openai", ProviderModel = "gpt-image-2", GenerationMode = "instant_headshot", GenerationStatus = "succeeded", FailureReason = "raw-preview:protected/raw.png", CreatedAt = now.AddDays(-1), ScheduledDeletionDate = now.AddDays(29) },
+            new ProcessedImage { UserProfileId = profile.Id, OriginalImageUrl = "o", ProcessedImageUrl = "failed", Style = "linkedin", IsGenerated = true, Provider = "openai", ProviderModel = "gpt-image-2", GenerationMode = "instant_headshot", GenerationStatus = "failed", FailureReason = "ProviderTimeout", CreatedAt = now.AddDays(-1), ScheduledDeletionDate = now.AddDays(29) },
+            new ProcessedImage { UserProfileId = profile.Id, OriginalImageUrl = "o", ProcessedImageUrl = "replicate", Style = "executive", IsGenerated = true, Provider = "replicate", ProviderModel = "legacy", GenerationStatus = "succeeded", CreatedAt = now.AddDays(-1), ScheduledDeletionDate = now.AddDays(29) });
+        context.UserPackageEntitlements.AddRange(
+            new UserPackageEntitlement { UserId = userId, OutcomePackageDefinitionId = starter.Id, Status = PackageEntitlementStatus.Active, RemainingCandidates = 2, RemainingRefinements = 1, CreatedAt = now.AddDays(-1), UpdatedAt = now.AddDays(-1) },
+            new UserPackageEntitlement { UserId = userId, OutcomePackageDefinitionId = pro.Id, Status = PackageEntitlementStatus.Consumed, RemainingCandidates = 0, RemainingRefinements = 0, CreatedAt = now.AddDays(-20), UpdatedAt = now.AddDays(-20) });
+        context.ModelCreationRequests.Add(new ModelCreationRequest { UserId = userId, ModelName = "advanced", CreatedAt = now.AddDays(-1) });
+        await context.SaveChangesAsync();
+
+        var userManager = UserManagerMockFactory.Create();
+        var service = CreateService(context, userManager.Object);
+
+        var health = await service.GetProductHealthAsync("7d");
+
+        Assert.Equal(1, health.Funnel.Uploads);
+        Assert.Equal(1, health.Funnel.SuccessfulPreviewGenerations);
+        Assert.Equal(1, health.Funnel.StarterPurchases);
+        Assert.Equal(0, health.Funnel.ProPurchases);
+        Assert.False(health.Funnel.PreviewGenerationSuccessRateAvailable);
+        Assert.Null(health.Funnel.PreviewGenerationSuccessRate);
+        Assert.True(health.Funnel.PreviewToPaidConversionRateAvailable);
+        Assert.Equal(1m, health.Funnel.PreviewToPaidConversionRate);
+        Assert.False(health.Funnel.ExportDownloadsAvailable);
+        Assert.Null(health.Funnel.ExportDownloads);
+        Assert.False(health.Funnel.GenerationLatencyAvailable);
+        Assert.Equal(1, health.PackageFulfillment.ActiveEntitlements);
+        Assert.Equal(0, health.PackageFulfillment.ConsumedEntitlements);
+        Assert.Equal(1, health.FailureQueue.FailedGenerations);
+        Assert.Equal(1, health.ReplicateRetirement.ReplicateGeneratedImages);
+        Assert.Equal(1, health.ReplicateRetirement.AdvancedPhotoshootRequests);
+        Assert.False(health.ReplicateRetirement.LatencySignalAvailable);
+        Assert.False(health.ReplicateRetirement.QualityComplaintSignalAvailable);
+    }
+
+    [Fact]
     public async Task GetUserDiagnosticsAsync_ResolvesRetentionActorLabel()
     {
         using var context = CreateContext();

--- a/AI.ProfilePhotoMaker.API/Controllers/AdminController.cs
+++ b/AI.ProfilePhotoMaker.API/Controllers/AdminController.cs
@@ -198,6 +198,21 @@ public class AdminController : BaseController
         }
     }
 
+    [HttpGet("product-health")]
+    public async Task<IActionResult> GetProductHealth([FromQuery] string window = "7d")
+    {
+        try
+        {
+            var productHealth = await _adminService.GetProductHealthAsync(window);
+            return SuccessResponse(productHealth);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load admin product health for window {Window}", S(window));
+            return ErrorResponse("InternalError", "Failed to load product health", 500);
+        }
+    }
+
     [HttpPost("cleanup-orphaned-model")]
     public async Task<IActionResult> CleanupOrphanedModel([FromBody] CleanupRequest request)
     {

--- a/AI.ProfilePhotoMaker.API/Controllers/AuthController.cs
+++ b/AI.ProfilePhotoMaker.API/Controllers/AuthController.cs
@@ -922,7 +922,7 @@ namespace AI.ProfilePhotoMaker.API.Controllers
                         Gender = null,  // Will be set during profile completion if needed
                         Ethnicity = null,  // Will be set during profile completion if needed
                         SubscriptionTier = SubscriptionTier.Basic,
-                        Credits = 25,
+                        Credits = 0,
                         LastCreditReset = DateTime.UtcNow,
                         CreatedAt = DateTime.UtcNow,
                         UpdatedAt = DateTime.UtcNow
@@ -964,7 +964,7 @@ namespace AI.ProfilePhotoMaker.API.Controllers
                             Gender = null,
                             Ethnicity = null,
                             SubscriptionTier = SubscriptionTier.Basic,
-                            Credits = 25,
+                            Credits = 0,
                             LastCreditReset = DateTime.UtcNow,
                             CreatedAt = DateTime.UtcNow,
                             UpdatedAt = DateTime.UtcNow

--- a/AI.ProfilePhotoMaker.API/Controllers/ProfileManagementController.cs
+++ b/AI.ProfilePhotoMaker.API/Controllers/ProfileManagementController.cs
@@ -129,7 +129,7 @@ namespace AI.ProfilePhotoMaker.API.Controllers
                     LastName = dto.LastName,
                     Gender = dto.Gender,
                     Ethnicity = dto.Ethnicity,
-                    Credits = 5, // Start with basic tier credits
+                    Credits = 0, // Free Preview replaces signup credits
                     LastCreditReset = DateTime.UtcNow,
                     SubscriptionTier = SubscriptionTier.Basic
                 };

--- a/AI.ProfilePhotoMaker.API/Data/IUserProfileRepository.cs
+++ b/AI.ProfilePhotoMaker.API/Data/IUserProfileRepository.cs
@@ -64,6 +64,10 @@ public class ProcessedImageDto
     public DateTime CreatedAt { get; set; }
     public bool IsGenerated { get; set; }
     public bool IsOriginalUpload { get; set; }
+    public string? Provider { get; set; }
+    public string? ProviderModel { get; set; }
+    public string? GenerationStatus { get; set; }
+    public string? FailureReason { get; set; }
 }
 
 public class UserProfileStatsDto

--- a/AI.ProfilePhotoMaker.API/Data/UserProfileRepository.cs
+++ b/AI.ProfilePhotoMaker.API/Data/UserProfileRepository.cs
@@ -112,7 +112,11 @@ public class UserProfileRepository : IUserProfileRepository
                 Style = i.Style,
                 CreatedAt = i.CreatedAt,
                 IsGenerated = i.IsGenerated,
-                IsOriginalUpload = i.IsOriginalUpload
+                IsOriginalUpload = i.IsOriginalUpload,
+                Provider = i.Provider,
+                ProviderModel = i.ProviderModel,
+                GenerationStatus = i.GenerationStatus,
+                FailureReason = i.FailureReason
             })
             .ToListAsync();
 
@@ -165,7 +169,11 @@ public class UserProfileRepository : IUserProfileRepository
                 Style = i.Style,
                 CreatedAt = i.CreatedAt,
                 IsGenerated = i.IsGenerated,
-                IsOriginalUpload = i.IsOriginalUpload
+                IsOriginalUpload = i.IsOriginalUpload,
+                Provider = i.Provider,
+                ProviderModel = i.ProviderModel,
+                GenerationStatus = i.GenerationStatus,
+                FailureReason = i.FailureReason
             })
             .ToListAsync();
 
@@ -210,7 +218,11 @@ public class UserProfileRepository : IUserProfileRepository
                 Style = i.Style,
                 CreatedAt = i.CreatedAt,
                 IsGenerated = i.IsGenerated,
-                IsOriginalUpload = i.IsOriginalUpload
+                IsOriginalUpload = i.IsOriginalUpload,
+                Provider = i.Provider,
+                ProviderModel = i.ProviderModel,
+                GenerationStatus = i.GenerationStatus,
+                FailureReason = i.FailureReason
             })
             .ToListAsync();
 

--- a/AI.ProfilePhotoMaker.API/Models/DTOs/AdminDtos.cs
+++ b/AI.ProfilePhotoMaker.API/Models/DTOs/AdminDtos.cs
@@ -29,6 +29,7 @@ public class AdminUserDiagnosticsDto
     public AdminUserDetailDto User { get; set; } = new();
     public AdminUserMetricsDto Metrics { get; set; } = new();
     public List<AdminCreditPurchaseHistoryDto> RecentPurchases { get; set; } = new();
+    public List<AdminPackageEntitlementDto> PackageEntitlements { get; set; } = new();
     public List<AdminRecentImageDto> RecentImages { get; set; } = new();
     public List<AdminUserActivityDto> ActivityHistory { get; set; } = new();
     public List<AdminUserAdminActionDto> RecentAdminActions { get; set; } = new();
@@ -62,6 +63,21 @@ public class AdminCreditPurchaseHistoryDto
     public DateTime? CompletedAt { get; set; }
 }
 
+public class AdminPackageEntitlementDto
+{
+    public int Id { get; set; }
+    public string PackageCode { get; set; } = string.Empty;
+    public string PackageName { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+    public int RemainingCandidates { get; set; }
+    public int RemainingRefinements { get; set; }
+    public int RemainingPremiumAugmentations { get; set; }
+    public bool PlatformExportKitAvailable { get; set; }
+    public DateTime? ActivatedAt { get; set; }
+    public DateTime? ConsumedAt { get; set; }
+    public DateTime? ExpiresAt { get; set; }
+}
+
 public class AdminRecentImageDto
 {
     public int Id { get; set; }
@@ -71,6 +87,10 @@ public class AdminRecentImageDto
     public DateTime CreatedAt { get; set; }
     public bool IsGenerated { get; set; }
     public bool IsOriginalUpload { get; set; }
+    public string? Provider { get; set; }
+    public string? ProviderModel { get; set; }
+    public string? GenerationStatus { get; set; }
+    public string? FailureReason { get; set; }
 }
 
 public class AdminUserActivityDto
@@ -170,6 +190,92 @@ public class AdminDashboardDto
     public int TotalCreditsOutstanding { get; set; }
     public long TotalCreditsPurchased { get; set; }
     public int ActiveCoupons { get; set; }
+}
+
+public class AdminProductHealthDto
+{
+    public string Window { get; set; } = "7d";
+    public DateTime FromUtc { get; set; }
+    public DateTime ToUtc { get; set; }
+    public AdminProductFunnelDto Funnel { get; set; } = new();
+    public List<AdminPackageMixDto> PackageMix { get; set; } = new();
+    public AdminPackageFulfillmentDto PackageFulfillment { get; set; } = new();
+    public List<AdminProviderHealthDto> ProviderHealth { get; set; } = new();
+    public AdminFailureQueueDto FailureQueue { get; set; } = new();
+    public AdminReplicateRetirementDto ReplicateRetirement { get; set; } = new();
+}
+
+public class AdminProductFunnelDto
+{
+    public int Uploads { get; set; }
+    public int SuccessfulPreviewGenerations { get; set; }
+    public int PaidPackagePurchases { get; set; }
+    public int StarterPurchases { get; set; }
+    public int ProPurchases { get; set; }
+    public int? ExportDownloads { get; set; }
+    public bool ExportDownloadsAvailable { get; set; }
+    public int? MedianGenerationTimeMs { get; set; }
+    public int? P95GenerationTimeMs { get; set; }
+    public bool GenerationLatencyAvailable { get; set; }
+    public decimal? PreviewGenerationSuccessRate { get; set; }
+    public bool PreviewGenerationSuccessRateAvailable { get; set; }
+    public decimal? PreviewToPaidConversionRate { get; set; }
+    public bool PreviewToPaidConversionRateAvailable { get; set; }
+}
+
+public class AdminPackageMixDto
+{
+    public string Code { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public int Purchases { get; set; }
+    public decimal RevenueProxy { get; set; }
+}
+
+public class AdminPackageFulfillmentDto
+{
+    public int ActiveEntitlements { get; set; }
+    public int ConsumedEntitlements { get; set; }
+    public int ExpiredEntitlements { get; set; }
+    public int RefundedEntitlements { get; set; }
+    public int RemainingCandidates { get; set; }
+    public int RemainingRefinements { get; set; }
+    public int RemainingPremiumAugmentations { get; set; }
+    public int ExportKitsAvailable { get; set; }
+}
+
+public class AdminProviderHealthDto
+{
+    public string Provider { get; set; } = "unknown";
+    public string Model { get; set; } = "unknown";
+    public int GeneratedImages { get; set; }
+    public int FailedImages { get; set; }
+    public decimal FailureRate { get; set; }
+}
+
+public class AdminFailureQueueDto
+{
+    public int FailedGenerations { get; set; }
+    public List<AdminFailureReasonDto> TopReasons { get; set; } = new();
+}
+
+public class AdminFailureReasonDto
+{
+    public string Reason { get; set; } = "unknown";
+    public int Count { get; set; }
+}
+
+public class AdminReplicateRetirementDto
+{
+    public int OpenAiGeneratedImages { get; set; }
+    public int ReplicateGeneratedImages { get; set; }
+    public decimal ReplicateUsageShare { get; set; }
+    public bool LatencySignalAvailable { get; set; }
+    public int FallbackGeneratedImages { get; set; }
+    public bool FallbackUseSignalAvailable { get; set; }
+    public int AdvancedPhotoshootRequests { get; set; }
+    public bool AdvancedPhotoshootUsageSignalAvailable { get; set; }
+    public bool QualityComplaintSignalAvailable { get; set; }
+    public string Recommendation { get; set; } = string.Empty;
 }
 
 public class AdminActionReasonDto

--- a/AI.ProfilePhotoMaker.API/Models/UserProfile.cs
+++ b/AI.ProfilePhotoMaker.API/Models/UserProfile.cs
@@ -17,7 +17,7 @@ public class UserProfile
 
     // Basic tier and subscription management
     public SubscriptionTier SubscriptionTier { get; set; } = SubscriptionTier.Basic;
-    public int Credits { get; set; } = 25; // Unified credits balance (tops up to 5 weekly if below)
+    public int Credits { get; set; } = 0; // Internal credit ledger balance; new users start with Free Preview instead
     public DateTime LastCreditReset { get; set; } = DateTime.UtcNow;
 
     public List<ProcessedImage> ProcessedImages { get; set; } = new List<ProcessedImage>();

--- a/AI.ProfilePhotoMaker.API/Services/AdminService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/AdminService.cs
@@ -117,6 +117,27 @@ public class AdminService : IAdminService
             .OrderByDescending(log => log.CreatedAt)
             .Take(8)
             .ToListAsync();
+        var packageEntitlements = await _context.UserPackageEntitlements
+            .AsNoTracking()
+            .Include(entitlement => entitlement.OutcomePackageDefinition)
+            .Where(entitlement => entitlement.UserId == userId)
+            .OrderByDescending(entitlement => entitlement.CreatedAt)
+            .Take(8)
+            .Select(entitlement => new AdminPackageEntitlementDto
+            {
+                Id = entitlement.Id,
+                PackageCode = entitlement.OutcomePackageDefinition.Code,
+                PackageName = entitlement.OutcomePackageDefinition.Name,
+                Status = entitlement.Status.ToString(),
+                RemainingCandidates = entitlement.RemainingCandidates,
+                RemainingRefinements = entitlement.RemainingRefinements,
+                RemainingPremiumAugmentations = entitlement.RemainingPremiumAugmentations,
+                PlatformExportKitAvailable = entitlement.PlatformExportKitAvailable,
+                ActivatedAt = entitlement.ActivatedAt,
+                ConsumedAt = entitlement.ConsumedAt,
+                ExpiresAt = entitlement.ExpiresAt
+            })
+            .ToListAsync();
         var roles = await _userManager.GetRolesAsync(user) ?? Array.Empty<string>();
         var adminEmails = await ResolveAdminEmailsAsync(adminAuditLogs);
 
@@ -146,7 +167,11 @@ public class AdminService : IAdminService
                 Style = string.IsNullOrWhiteSpace(image.Style) ? null : image.Style,
                 CreatedAt = image.CreatedAt,
                 IsGenerated = image.IsGenerated,
-                IsOriginalUpload = image.IsOriginalUpload
+                IsOriginalUpload = image.IsOriginalUpload,
+                Provider = image.Provider,
+                ProviderModel = image.ProviderModel,
+                GenerationStatus = image.GenerationStatus,
+                FailureReason = image.FailureReason
             })
             .ToList() ?? new List<AdminRecentImageDto>();
 
@@ -208,6 +233,7 @@ public class AdminService : IAdminService
                 HasUsageHistory = usageLogs.Count > 0 || recentPurchases.Count > 0 || recentImages.Count > 0
             },
             RecentPurchases = recentPurchases,
+            PackageEntitlements = packageEntitlements,
             RecentImages = recentImages,
             ActivityHistory = activityHistory,
             RecentAdminActions = recentAdminActions
@@ -608,6 +634,208 @@ public class AdminService : IAdminService
             TotalCreditsOutstanding = totalCreditsOutstanding,
             TotalCreditsPurchased = totalCreditsPurchased,
             ActiveCoupons = activeCoupons
+        };
+    }
+
+    public async Task<AdminProductHealthDto> GetProductHealthAsync(string window)
+    {
+        var toUtc = DateTime.UtcNow;
+        var normalizedWindow = NormalizeProductHealthWindow(window);
+        var fromUtc = normalizedWindow switch
+        {
+            "24h" => toUtc.AddHours(-24),
+            "30d" => toUtc.AddDays(-30),
+            "all" => DateTime.MinValue,
+            _ => toUtc.AddDays(-7)
+        };
+
+        var imagesInWindow = _context.ProcessedImages.AsNoTracking()
+            .Where(image => image.CreatedAt >= fromUtc && image.CreatedAt <= toUtc);
+        var entitlementsInWindow = _context.UserPackageEntitlements.AsNoTracking()
+            .Include(entitlement => entitlement.OutcomePackageDefinition)
+            .Where(entitlement => entitlement.CreatedAt >= fromUtc && entitlement.CreatedAt <= toUtc);
+
+        var uploads = await imagesInWindow.CountAsync(image => image.IsOriginalUpload);
+        var successfulPreviewGenerations = await imagesInWindow.CountAsync(image =>
+            image.IsGenerated &&
+            image.GenerationStatus != "failed" &&
+            image.GenerationMode == "instant_headshot" &&
+            image.FailureReason != null &&
+            image.FailureReason.StartsWith("raw-preview:"));
+        var generatedImages = await imagesInWindow.CountAsync(image => image.IsGenerated && image.GenerationStatus != "failed");
+        var failedGenerations = await imagesInWindow.CountAsync(image => image.IsGenerated && image.GenerationStatus == "failed");
+        var paidPackagePurchases = await entitlementsInWindow.CountAsync(entitlement => entitlement.OutcomePackageDefinition.Price > 0);
+        var starterPurchases = await entitlementsInWindow.CountAsync(entitlement =>
+            entitlement.OutcomePackageDefinition.Price > 0 &&
+            (entitlement.OutcomePackageDefinition.Code.ToLower().Contains("starter") ||
+             entitlement.OutcomePackageDefinition.Name.ToLower().Contains("starter")));
+        var proPurchases = await entitlementsInWindow.CountAsync(entitlement =>
+            entitlement.OutcomePackageDefinition.Price > 0 &&
+            (entitlement.OutcomePackageDefinition.Code.ToLower().Contains("pro") ||
+             entitlement.OutcomePackageDefinition.Name.ToLower().Contains("pro")));
+
+        var packageMix = await entitlementsInWindow
+            .Where(entitlement => entitlement.OutcomePackageDefinition.Price > 0)
+            .GroupBy(entitlement => new
+            {
+                entitlement.OutcomePackageDefinition.Code,
+                entitlement.OutcomePackageDefinition.Name,
+                entitlement.OutcomePackageDefinition.Price
+            })
+            .Select(group => new AdminPackageMixDto
+            {
+                Code = group.Key.Code,
+                Name = group.Key.Name,
+                Purchases = group.Count(),
+                RevenueProxy = group.Count() * group.Key.Price
+            })
+            .OrderByDescending(package => package.Purchases)
+            .ToListAsync();
+
+        var fulfillmentRows = await entitlementsInWindow.ToListAsync();
+        var providerHealth = await imagesInWindow
+            .Where(image => image.IsGenerated)
+            .GroupBy(image => new
+            {
+                Provider = image.Provider ?? "unknown",
+                Model = image.ProviderModel ?? "unknown"
+            })
+            .Select(group => new AdminProviderHealthDto
+            {
+                Provider = group.Key.Provider,
+                Model = group.Key.Model,
+                GeneratedImages = group.Count(image => image.GenerationStatus != "failed"),
+                FailedImages = group.Count(image => image.GenerationStatus == "failed")
+            })
+            .OrderByDescending(provider => provider.GeneratedImages + provider.FailedImages)
+            .ToListAsync();
+
+        foreach (var provider in providerHealth)
+        {
+            var total = provider.GeneratedImages + provider.FailedImages;
+            provider.FailureRate = total == 0 ? 0 : Math.Round((decimal)provider.FailedImages / total, 4);
+        }
+
+        var topFailureReasons = await imagesInWindow
+            .Where(image => image.IsGenerated && image.GenerationStatus == "failed")
+            .GroupBy(image => image.FailureReason ?? "unknown")
+            .Select(group => new AdminFailureReasonDto { Reason = group.Key, Count = group.Count() })
+            .OrderByDescending(reason => reason.Count)
+            .Take(5)
+            .ToListAsync();
+
+        var openAiGenerated = providerHealth
+            .Where(provider => provider.Provider.Equals("openai", StringComparison.OrdinalIgnoreCase))
+            .Sum(provider => provider.GeneratedImages);
+        var replicateGenerated = providerHealth
+            .Where(provider => provider.Provider.Equals("replicate", StringComparison.OrdinalIgnoreCase))
+            .Sum(provider => provider.GeneratedImages);
+        var providerTotal = openAiGenerated + replicateGenerated;
+        var replicateShare = providerTotal == 0 ? 0 : Math.Round((decimal)replicateGenerated / providerTotal, 4);
+        var fallbackGenerated = providerHealth
+            .Where(provider => !provider.Provider.Equals("openai", StringComparison.OrdinalIgnoreCase) &&
+                               !provider.Provider.Equals("replicate", StringComparison.OrdinalIgnoreCase))
+            .Sum(provider => provider.GeneratedImages);
+        var advancedPhotoshootRequests = await _context.ModelCreationRequests.AsNoTracking()
+            .CountAsync(request => request.CreatedAt >= fromUtc && request.CreatedAt <= toUtc);
+        var latencySignalAvailable = false;
+        var qualityComplaintSignalAvailable = false;
+        var retirementRecommendation = BuildReplicateRetirementRecommendation(
+            replicateShare,
+            openAiGenerated,
+            replicateGenerated,
+            fallbackGenerated,
+            advancedPhotoshootRequests,
+            latencySignalAvailable,
+            qualityComplaintSignalAvailable);
+
+        return new AdminProductHealthDto
+        {
+            Window = normalizedWindow,
+            FromUtc = fromUtc,
+            ToUtc = toUtc,
+            Funnel = new AdminProductFunnelDto
+            {
+                Uploads = uploads,
+                SuccessfulPreviewGenerations = successfulPreviewGenerations,
+                PaidPackagePurchases = paidPackagePurchases,
+                StarterPurchases = starterPurchases,
+                ProPurchases = proPurchases,
+                ExportDownloads = null,
+                ExportDownloadsAvailable = false,
+                MedianGenerationTimeMs = null,
+                P95GenerationTimeMs = null,
+                GenerationLatencyAvailable = false,
+                PreviewGenerationSuccessRate = null,
+                PreviewGenerationSuccessRateAvailable = false,
+                PreviewToPaidConversionRate = successfulPreviewGenerations == 0 ? null : Math.Round((decimal)paidPackagePurchases / successfulPreviewGenerations, 4),
+                PreviewToPaidConversionRateAvailable = successfulPreviewGenerations > 0
+            },
+            PackageMix = packageMix,
+            PackageFulfillment = new AdminPackageFulfillmentDto
+            {
+                ActiveEntitlements = fulfillmentRows.Count(entitlement => entitlement.Status == PackageEntitlementStatus.Active),
+                ConsumedEntitlements = fulfillmentRows.Count(entitlement => entitlement.Status == PackageEntitlementStatus.Consumed),
+                ExpiredEntitlements = fulfillmentRows.Count(entitlement => entitlement.Status == PackageEntitlementStatus.Expired),
+                RefundedEntitlements = fulfillmentRows.Count(entitlement => entitlement.Status == PackageEntitlementStatus.Refunded),
+                RemainingCandidates = fulfillmentRows.Sum(entitlement => entitlement.RemainingCandidates),
+                RemainingRefinements = fulfillmentRows.Sum(entitlement => entitlement.RemainingRefinements),
+                RemainingPremiumAugmentations = fulfillmentRows.Sum(entitlement => entitlement.RemainingPremiumAugmentations),
+                ExportKitsAvailable = fulfillmentRows.Count(entitlement => entitlement.PlatformExportKitAvailable)
+            },
+            ProviderHealth = providerHealth,
+            FailureQueue = new AdminFailureQueueDto
+            {
+                FailedGenerations = failedGenerations,
+                TopReasons = topFailureReasons
+            },
+            ReplicateRetirement = new AdminReplicateRetirementDto
+            {
+                OpenAiGeneratedImages = openAiGenerated,
+                ReplicateGeneratedImages = replicateGenerated,
+                ReplicateUsageShare = replicateShare,
+                LatencySignalAvailable = latencySignalAvailable,
+                FallbackGeneratedImages = fallbackGenerated,
+                FallbackUseSignalAvailable = true,
+                AdvancedPhotoshootRequests = advancedPhotoshootRequests,
+                AdvancedPhotoshootUsageSignalAvailable = true,
+                QualityComplaintSignalAvailable = qualityComplaintSignalAvailable,
+                Recommendation = retirementRecommendation
+            }
+        };
+    }
+
+    private static string BuildReplicateRetirementRecommendation(
+        decimal replicateShare,
+        int openAiGenerated,
+        int replicateGenerated,
+        int fallbackGenerated,
+        int advancedPhotoshootRequests,
+        bool latencySignalAvailable,
+        bool qualityComplaintSignalAvailable)
+    {
+        var blockers = new List<string>();
+        if (replicateShare > 0.05m) blockers.Add("Replicate usage remains above 5%");
+        if (replicateGenerated > 0) blockers.Add("Replicate still produced images in this window");
+        if (fallbackGenerated > 0) blockers.Add("fallback provider usage is present");
+        if (advancedPhotoshootRequests > 0) blockers.Add("advanced custom photoshoot requests are present");
+        if (!latencySignalAvailable) blockers.Add("OpenAI median/p95 latency is not instrumented yet");
+        if (!qualityComplaintSignalAvailable) blockers.Add("quality complaint baseline is not instrumented yet");
+        if (openAiGenerated == 0) blockers.Add("OpenAI usage is not established in this window");
+
+        return blockers.Count == 0
+            ? "Replicate retirement looks safe for this window. Confirm support and quality trends before disabling fallback."
+            : $"Do not retire Replicate yet: {string.Join("; ", blockers)}.";
+    }
+
+    private static string NormalizeProductHealthWindow(string? window)
+    {
+        return window?.Trim().ToLowerInvariant() switch
+        {
+            "24h" => "24h",
+            "30d" => "30d",
+            "all" or "all-time" or "alltime" => "all",
+            _ => "7d"
         };
     }
 

--- a/AI.ProfilePhotoMaker.API/Services/Authentication/AuthService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/Authentication/AuthService.cs
@@ -95,7 +95,7 @@ public class AuthService : IAuthService
             Gender = model.Gender,
             Ethnicity = model.Ethnicity,
             SubscriptionTier = SubscriptionTier.Basic,
-            Credits = 25,
+            Credits = 0,
             LastCreditReset = DateTime.UtcNow,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow
@@ -316,7 +316,7 @@ public class AuthService : IAuthService
                 Gender = model.Gender,
                 Ethnicity = model.Ethnicity,
                 SubscriptionTier = SubscriptionTier.Basic,
-                Credits = 25,
+                Credits = 0,
                 LastCreditReset = DateTime.UtcNow,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow

--- a/AI.ProfilePhotoMaker.API/Services/BasicTierService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/BasicTierService.cs
@@ -8,8 +8,7 @@ public class BasicTierService : IBasicTierService
 {
     private readonly ApplicationDbContext _context;
     private readonly ILogger<BasicTierService> _logger;
-    private const int WeeklyCredits = 5; // Weekly top-up amount (unchanged)
-    private const int SignupCredits = 25; // Free trial: 15 (train) + 5x2 (2 headshots)
+    private const int WeeklyCredits = 5; // Weekly top-up amount for legacy credit flows
     private const int DaysInWeek = 7;
     public BasicTierService(ApplicationDbContext context, ILogger<BasicTierService> logger)
     {

--- a/AI.ProfilePhotoMaker.API/Services/IAdminService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/IAdminService.cs
@@ -17,4 +17,5 @@ public interface IAdminService
     Task<bool> DeleteCouponAsync(int couponId, string adminUserId);
     Task<(List<AdminAuditLogDto> Logs, int TotalCount)> GetAuditLogsAsync(int page, int pageSize, string? actionFilter);
     Task<AdminDashboardDto> GetDashboardAsync();
+    Task<AdminProductHealthDto> GetProductHealthAsync(string window);
 }

--- a/AI.ProfilePhotoMaker.API/Services/ModelDiscoveryService.cs
+++ b/AI.ProfilePhotoMaker.API/Services/ModelDiscoveryService.cs
@@ -396,7 +396,7 @@ public class ModelDiscoveryService : IModelDiscoveryService
                 {
                     UserId = userId,
                     SubscriptionTier = SubscriptionTier.Basic,
-                    Credits = 5,
+                    Credits = 0,
                     LastCreditReset = DateTime.UtcNow
                 };
                 _context.UserProfiles.Add(userProfile);
@@ -595,7 +595,7 @@ public class ModelDiscoveryService : IModelDiscoveryService
                 {
                     UserId = userId,
                     SubscriptionTier = SubscriptionTier.Basic,
-                    Credits = 5,
+                    Credits = 0,
                     LastCreditReset = DateTime.UtcNow
                 };
                 _context.UserProfiles.Add(userProfile);

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-audit-log/admin-audit-log.component.html
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-audit-log/admin-audit-log.component.html
@@ -9,6 +9,7 @@
 
   <nav class="admin-nav">
     <a routerLink="/admin/dashboard" routerLinkActive="is-active">Overview</a>
+    <a routerLink="/admin/product-health" routerLinkActive="is-active">Product Health</a>
     <a routerLink="/admin/users" routerLinkActive="is-active">Users</a>
     <a routerLink="/admin/coupons" routerLinkActive="is-active">Coupons</a>
     <a routerLink="/admin/audit-log" routerLinkActive="is-active">Audit Log</a>

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-campaigns/admin-campaigns.component.html
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-campaigns/admin-campaigns.component.html
@@ -11,6 +11,7 @@
 
   <nav class="admin-nav">
     <a routerLink="/admin/dashboard" routerLinkActive="is-active">Overview</a>
+    <a routerLink="/admin/product-health" routerLinkActive="is-active">Product Health</a>
     <a routerLink="/admin/users" routerLinkActive="is-active">Users</a>
     <a routerLink="/admin/coupons" routerLinkActive="is-active">Coupons</a>
     <a routerLink="/admin/audit-log" routerLinkActive="is-active">Audit Log</a>

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-coupons/admin-coupons.component.html
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-coupons/admin-coupons.component.html
@@ -9,6 +9,7 @@
 
   <nav class="admin-nav">
     <a routerLink="/admin/dashboard" routerLinkActive="is-active">Overview</a>
+    <a routerLink="/admin/product-health" routerLinkActive="is-active">Product Health</a>
     <a routerLink="/admin/users" routerLinkActive="is-active">Users</a>
     <a routerLink="/admin/coupons" routerLinkActive="is-active">Coupons</a>
     <a routerLink="/admin/audit-log" routerLinkActive="is-active">Audit Log</a>

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-dashboard/admin-dashboard.component.html
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-dashboard/admin-dashboard.component.html
@@ -3,12 +3,13 @@
     <div>
       <p class="admin-kicker">Operations Center</p>
       <h1>Admin Dashboard</h1>
-      <p class="admin-subtitle">Manage users, credits, coupons, and operational audits.</p>
+      <p class="admin-subtitle">Manage account operations, promotions, campaigns, and audit controls.</p>
     </div>
   </header>
 
   <nav class="admin-nav">
     <a routerLink="/admin/dashboard" routerLinkActive="is-active">Overview</a>
+    <a routerLink="/admin/product-health" routerLinkActive="is-active">Product Health</a>
     <a routerLink="/admin/users" routerLinkActive="is-active">Users</a>
     <a routerLink="/admin/coupons" routerLinkActive="is-active">Coupons</a>
     <a routerLink="/admin/audit-log" routerLinkActive="is-active">Audit Log</a>
@@ -36,11 +37,11 @@
       <p>Active Users</p>
       <h2>{{ dashboard.activeUsers }}</h2>
     </article>
-    <article class="metric-card">
+    <article class="metric-card metric-card-secondary">
       <p>Credits Outstanding</p>
       <h2>{{ dashboard.totalCreditsOutstanding }}</h2>
     </article>
-    <article class="metric-card">
+    <article class="metric-card metric-card-secondary">
       <p>Credits Purchased</p>
       <h2>{{ dashboard.totalCreditsPurchased }}</h2>
     </article>
@@ -50,10 +51,22 @@
     </article>
   </div>
 
+  <section class="admin-panel product-health-summary" *ngIf="!isLoading && !error">
+    <div class="panel-heading">
+      <div>
+        <h2>Product Health</h2>
+        <p>
+          Track upload-to-preview conversion, package fulfillment, provider health, and Replicate retirement signals.
+        </p>
+      </div>
+      <a routerLink="/admin/product-health" class="btn btn-primary">Open Product Health</a>
+    </div>
+  </section>
+
   <section class="quick-actions">
     <a routerLink="/admin/users" class="action-card">
       <h3>User Management</h3>
-      <p>Search accounts, lock/unlock users, and adjust credit balances.</p>
+      <p>Search accounts, inspect package state, resolve access issues, and apply controlled account actions.</p>
     </a>
     <a routerLink="/admin/coupons" class="action-card">
       <h3>Coupon Management</h3>

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-dashboard/admin-dashboard.component.sass
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-dashboard/admin-dashboard.component.sass
@@ -22,6 +22,12 @@
     font-size: 1.7rem
     line-height: 1
 
+.metric-card-secondary
+  opacity: 0.82
+
+.product-health-summary
+  margin-bottom: 1.2rem
+
 .quick-actions
   display: grid
   grid-template-columns: repeat(3, minmax(0, 1fr))

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-product-health/admin-product-health.component.html
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-product-health/admin-product-health.component.html
@@ -1,0 +1,245 @@
+<section class="admin-shell">
+  <header class="admin-header">
+    <div>
+      <p class="admin-kicker">Product Health</p>
+      <h1>Product Health</h1>
+      <p class="admin-subtitle">
+        Monitor upload-to-preview conversion, package fulfillment, provider health, and Replicate retirement signals.
+      </p>
+    </div>
+  </header>
+
+  <nav class="admin-nav">
+    <a routerLink="/admin/dashboard" routerLinkActive="is-active">Overview</a>
+    <a routerLink="/admin/product-health" routerLinkActive="is-active">Product Health</a>
+    <a routerLink="/admin/users" routerLinkActive="is-active">Users</a>
+    <a routerLink="/admin/coupons" routerLinkActive="is-active">Coupons</a>
+    <a routerLink="/admin/audit-log" routerLinkActive="is-active">Audit Log</a>
+    <a routerLink="/admin/campaigns" routerLinkActive="is-active">Campaigns</a>
+  </nav>
+
+  <section class="admin-panel window-panel">
+    <div class="panel-heading">
+      <div>
+        <h2>Reporting window</h2>
+        <p>Default is 7 days; switch to inspect incident windows or all-time package signal.</p>
+      </div>
+      <div class="window-toggle" role="group" aria-label="Product health reporting window">
+        <button
+          *ngFor="let window of windows"
+          type="button"
+          class="btn"
+          [class.btn-primary]="selectedWindow === window.value"
+          [class.btn-ghost]="selectedWindow !== window.value"
+          (click)="selectWindow(window.value)">
+          {{ window.label }}
+        </button>
+      </div>
+    </div>
+  </section>
+
+  <div *ngIf="isLoading" class="empty-state">
+    <p>Loading product health...</p>
+  </div>
+
+  <div *ngIf="error" class="error-text admin-panel" role="alert" aria-live="polite">
+    <p>{{ error }}</p>
+    <button class="btn btn-primary" (click)="loadProductHealth()" [disabled]="isLoading">Retry</button>
+  </div>
+
+  <ng-container *ngIf="!isLoading && !error && productHealth as health">
+    <section class="metrics-grid product-health-grid">
+      <article class="metric-card">
+        <p>Uploads</p>
+        <h2>{{ health.funnel.uploads }}</h2>
+      </article>
+      <article class="metric-card">
+        <p>Preview generations</p>
+        <h2>{{ health.funnel.successfulPreviewGenerations }}</h2>
+      </article>
+      <article class="metric-card">
+        <p>Preview success rate</p>
+        <h2>
+          {{
+            health.funnel.previewGenerationSuccessRateAvailable
+              ? formatRate(health.funnel.previewGenerationSuccessRate)
+              : 'Unavailable'
+          }}
+        </h2>
+      </article>
+      <article class="metric-card">
+        <p>Preview → paid</p>
+        <h2>
+          {{
+            health.funnel.previewToPaidConversionRateAvailable
+              ? formatRate(health.funnel.previewToPaidConversionRate)
+              : 'Unavailable'
+          }}
+        </h2>
+      </article>
+      <article class="metric-card">
+        <p>Starter purchases</p>
+        <h2>{{ health.funnel.starterPurchases }}</h2>
+      </article>
+      <article class="metric-card">
+        <p>Pro purchases</p>
+        <h2>{{ health.funnel.proPurchases }}</h2>
+      </article>
+      <article class="metric-card">
+        <p>Export downloads</p>
+        <h2>{{ health.funnel.exportDownloadsAvailable ? health.funnel.exportDownloads : 'Unavailable' }}</h2>
+      </article>
+      <article class="metric-card">
+        <p>Median generation time</p>
+        <h2>
+          {{ health.funnel.generationLatencyAvailable ? health.funnel.medianGenerationTimeMs + ' ms' : 'Unavailable' }}
+        </h2>
+      </article>
+      <article class="metric-card">
+        <p>P95 generation time</p>
+        <h2>
+          {{ health.funnel.generationLatencyAvailable ? health.funnel.p95GenerationTimeMs + ' ms' : 'Unavailable' }}
+        </h2>
+      </article>
+    </section>
+
+    <section class="panel-grid">
+      <article class="admin-panel">
+        <div class="panel-heading">
+          <h2>Package Mix</h2>
+          <span class="pill">{{ health.packageMix.length }} packages</span>
+        </div>
+        <div *ngIf="health.packageMix.length; else noPackages" class="stack-list">
+          <div class="stack-row" *ngFor="let pkg of health.packageMix">
+            <div>
+              <strong>{{ pkg.name }}</strong>
+              <p>{{ pkg.code }}</p>
+            </div>
+            <div class="row-metrics">
+              <span>{{ pkg.purchases }} purchases</span>
+              <span>{{ pkg.revenueProxy | currency }}</span>
+            </div>
+          </div>
+        </div>
+        <ng-template #noPackages>
+          <div class="empty-state">No paid package purchases in this window.</div>
+        </ng-template>
+      </article>
+
+      <article class="admin-panel">
+        <h2>Package Fulfillment</h2>
+        <div class="detail-grid">
+          <div class="detail-item">
+            <span>Active</span>
+            <strong>{{ health.packageFulfillment.activeEntitlements }}</strong>
+          </div>
+          <div class="detail-item">
+            <span>Consumed</span>
+            <strong>{{ health.packageFulfillment.consumedEntitlements }}</strong>
+          </div>
+          <div class="detail-item">
+            <span>Expired</span>
+            <strong>{{ health.packageFulfillment.expiredEntitlements }}</strong>
+          </div>
+          <div class="detail-item">
+            <span>Refunded</span>
+            <strong>{{ health.packageFulfillment.refundedEntitlements }}</strong>
+          </div>
+          <div class="detail-item">
+            <span>Remaining candidates</span>
+            <strong>{{ health.packageFulfillment.remainingCandidates }}</strong>
+          </div>
+          <div class="detail-item">
+            <span>Remaining refinements</span>
+            <strong>{{ health.packageFulfillment.remainingRefinements }}</strong>
+          </div>
+          <div class="detail-item">
+            <span>Remaining augmentations</span>
+            <strong>{{ health.packageFulfillment.remainingPremiumAugmentations }}</strong>
+          </div>
+          <div class="detail-item">
+            <span>Export kits available</span>
+            <strong>{{ health.packageFulfillment.exportKitsAvailable }}</strong>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <section class="panel-grid">
+      <article class="admin-panel">
+        <div class="panel-heading">
+          <h2>Provider Health</h2>
+          <span class="pill">OpenAI vs Replicate</span>
+        </div>
+        <div *ngIf="health.providerHealth.length; else noProviders" class="stack-list">
+          <div class="stack-row" *ngFor="let provider of health.providerHealth">
+            <div>
+              <strong>{{ provider.provider }}</strong>
+              <p>{{ provider.model }}</p>
+            </div>
+            <div class="row-metrics">
+              <span>{{ provider.generatedImages }} generated</span>
+              <span>{{ provider.failedImages }} failed</span>
+              <span>{{ formatRate(provider.failureRate) }} failure</span>
+            </div>
+          </div>
+        </div>
+        <ng-template #noProviders>
+          <div class="empty-state">No provider generation data in this window.</div>
+        </ng-template>
+      </article>
+
+      <article class="admin-panel">
+        <h2>Failure Queue</h2>
+        <p class="hero-copy">{{ health.failureQueue.failedGenerations }} failed generations in this window.</p>
+        <div *ngIf="health.failureQueue.topReasons.length; else noFailures" class="stack-list">
+          <div class="stack-row" *ngFor="let reason of health.failureQueue.topReasons">
+            <strong>{{ reason.reason }}</strong>
+            <span>{{ reason.count }}</span>
+          </div>
+        </div>
+        <ng-template #noFailures>
+          <div class="empty-state">No failed generations in this window.</div>
+        </ng-template>
+      </article>
+    </section>
+
+    <section class="admin-panel">
+      <div class="panel-heading">
+        <div>
+          <h2>Replicate Retirement Signal</h2>
+          <p>{{ health.replicateRetirement.recommendation }}</p>
+        </div>
+        <span class="pill">{{ formatRate(health.replicateRetirement.replicateUsageShare) }} Replicate share</span>
+      </div>
+      <div class="detail-grid">
+        <div class="detail-item">
+          <span>OpenAI generated</span>
+          <strong>{{ health.replicateRetirement.openAiGeneratedImages }}</strong>
+        </div>
+        <div class="detail-item">
+          <span>Replicate generated</span>
+          <strong>{{ health.replicateRetirement.replicateGeneratedImages }}</strong>
+        </div>
+        <div class="detail-item">
+          <span>Fallback generated</span>
+          <strong>{{ health.replicateRetirement.fallbackGeneratedImages }}</strong>
+        </div>
+        <div class="detail-item">
+          <span>Advanced photoshoot requests</span>
+          <strong>{{ health.replicateRetirement.advancedPhotoshootRequests }}</strong>
+        </div>
+        <div class="detail-item">
+          <span>OpenAI latency signal</span>
+          <strong>{{ health.replicateRetirement.latencySignalAvailable ? 'Available' : 'Unavailable' }}</strong>
+        </div>
+        <div class="detail-item">
+          <span>Quality complaint baseline</span>
+          <strong>
+            {{ health.replicateRetirement.qualityComplaintSignalAvailable ? 'Available' : 'Unavailable' }}
+          </strong>
+        </div>
+      </div>
+    </section>
+  </ng-container>
+</section>

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-product-health/admin-product-health.component.sass
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-product-health/admin-product-health.component.sass
@@ -1,0 +1,46 @@
+.window-panel
+  margin-bottom: 1rem
+
+.window-toggle
+  display: flex
+  flex-wrap: wrap
+  gap: 0.5rem
+
+.product-health-grid
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr))
+
+.panel-grid
+  display: grid
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr))
+  gap: 1rem
+  margin-top: 1rem
+
+.stack-list
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.stack-row
+  display: flex
+  justify-content: space-between
+  gap: 1rem
+  padding: 0.85rem 0
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18)
+
+  p
+    margin: 0.25rem 0 0
+    color: var(--text-muted, #64748b)
+
+.row-metrics
+  display: flex
+  flex-direction: column
+  align-items: flex-end
+  gap: 0.25rem
+  white-space: nowrap
+
+@media (max-width: 720px)
+  .stack-row
+    flex-direction: column
+
+  .row-metrics
+    align-items: flex-start

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-product-health/admin-product-health.component.ts
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-product-health/admin-product-health.component.ts
@@ -1,0 +1,65 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { AdminProductHealthDto, AdminService } from '../../services/admin.service';
+
+@Component({
+  selector: 'app-admin-product-health',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './admin-product-health.component.html',
+  styleUrls: ['../admin-shared.sass', './admin-product-health.component.sass'],
+})
+export class AdminProductHealthComponent implements OnInit {
+  readonly windows = [
+    { label: '24h', value: '24h' },
+    { label: '7d', value: '7d' },
+    { label: '30d', value: '30d' },
+    { label: 'All-time', value: 'all' },
+  ];
+
+  selectedWindow = '7d';
+  productHealth: AdminProductHealthDto | null = null;
+  isLoading = false;
+  error: string | null = null;
+
+  constructor(private readonly adminService: AdminService) {}
+
+  ngOnInit(): void {
+    this.loadProductHealth();
+  }
+
+  selectWindow(window: string): void {
+    if (this.selectedWindow === window) {
+      return;
+    }
+
+    this.selectedWindow = window;
+    this.loadProductHealth();
+  }
+
+  loadProductHealth(): void {
+    this.isLoading = true;
+    this.error = null;
+
+    this.adminService.getProductHealth(this.selectedWindow).subscribe({
+      next: data => {
+        this.productHealth = data;
+        this.isLoading = false;
+      },
+      error: err => {
+        console.error('Failed to load product health:', err);
+        this.error = err?.message || 'Failed to load product health. Please try again.';
+        this.isLoading = false;
+      },
+    });
+  }
+
+  formatRate(value: number | null | undefined): string {
+    if (value === null || value === undefined) {
+      return '0%';
+    }
+
+    return `${Math.round(value * 1000) / 10}%`;
+  }
+}

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-user-detail/admin-user-detail.component.html
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-user-detail/admin-user-detail.component.html
@@ -12,6 +12,7 @@
 
   <nav class="admin-nav">
     <a routerLink="/admin/dashboard" routerLinkActive="is-active">Overview</a>
+    <a routerLink="/admin/product-health" routerLinkActive="is-active">Product Health</a>
     <a routerLink="/admin/users" routerLinkActive="is-active" [routerLinkActiveOptions]="{ exact: false }">Users</a>
     <a routerLink="/admin/coupons" routerLinkActive="is-active">Coupons</a>
     <a routerLink="/admin/audit-log" routerLinkActive="is-active">Audit Log</a>
@@ -166,12 +167,53 @@
               diagnostics.metrics.currentCredits === 0 && diagnostics.metrics.hasUsageHistory
                 ? 'Credits likely consumed through usage'
                 : diagnostics.metrics.currentCredits === 0
-                  ? 'No usage history visible yet'
+                  ? 'Expected for new signups: Free Preview replaces signup credits'
                   : 'Credits remain available'
             }}
           </strong>
         </div>
       </div>
+    </section>
+
+    <section class="admin-panel">
+      <div class="panel-heading">
+        <h2>Package Entitlements</h2>
+        <span class="pill">{{ diagnostics.packageEntitlements.length }} records</span>
+      </div>
+      <div class="table-wrap" *ngIf="diagnostics.packageEntitlements.length; else noEntitlements">
+        <table>
+          <thead>
+            <tr>
+              <th>Package</th>
+              <th>Status</th>
+              <th>Candidates</th>
+              <th>Refinements</th>
+              <th>Augmentations</th>
+              <th>Export kit</th>
+              <th>Activated</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let entitlement of diagnostics.packageEntitlements">
+              <td>
+                {{ entitlement.packageName }}
+                <span class="mono-text">{{ entitlement.packageCode }}</span>
+              </td>
+              <td>{{ entitlement.status }}</td>
+              <td>{{ entitlement.remainingCandidates }}</td>
+              <td>{{ entitlement.remainingRefinements }}</td>
+              <td>{{ entitlement.remainingPremiumAugmentations }}</td>
+              <td>{{ entitlement.platformExportKitAvailable ? 'Available' : 'Unavailable' }}</td>
+              <td>{{ entitlement.activatedAt ? (entitlement.activatedAt | date: 'medium') : 'Not activated' }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <ng-template #noEntitlements>
+        <div class="empty-state">
+          No package entitlements yet. New users should start with Free Preview rather than signup credits.
+        </div>
+      </ng-template>
     </section>
 
     <section class="panel-grid">
@@ -260,8 +302,12 @@
             <div class="badge-row">
               <span class="pill">{{ image.kind }}</span>
               <span class="pill" *ngIf="image.style">{{ image.style }}</span>
+              <span class="pill" *ngIf="image.provider">{{ image.provider }}</span>
+              <span class="pill" *ngIf="image.providerModel">{{ image.providerModel }}</span>
+              <span class="pill" *ngIf="image.generationStatus">{{ image.generationStatus }}</span>
             </div>
             <p>{{ image.createdAt | date: 'medium' }}</p>
+            <p *ngIf="image.failureReason" class="error-text">Failure: {{ image.failureReason }}</p>
           </div>
         </article>
       </div>

--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-users/admin-users.component.html
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-users/admin-users.component.html
@@ -9,6 +9,7 @@
 
   <nav class="admin-nav">
     <a routerLink="/admin/dashboard" routerLinkActive="is-active">Overview</a>
+    <a routerLink="/admin/product-health" routerLinkActive="is-active">Product Health</a>
     <a routerLink="/admin/users" routerLinkActive="is-active">Users</a>
     <a routerLink="/admin/coupons" routerLinkActive="is-active">Coupons</a>
     <a routerLink="/admin/audit-log" routerLinkActive="is-active">Audit Log</a>

--- a/AI.ProfilePhotoMaker.UI/src/app/app.routes.ts
+++ b/AI.ProfilePhotoMaker.UI/src/app/app.routes.ts
@@ -558,6 +558,14 @@ export const routes: Routes = [
         title: 'Admin Dashboard',
       },
       {
+        path: 'product-health',
+        loadComponent: () =>
+          import('./admin/admin-product-health/admin-product-health.component').then(
+            m => m.AdminProductHealthComponent
+          ),
+        title: 'Product Health',
+      },
+      {
         path: 'users',
         loadComponent: () =>
           import('./admin/admin-users/admin-users.component').then(m => m.AdminUsersComponent),

--- a/AI.ProfilePhotoMaker.UI/src/app/services/admin.service.ts
+++ b/AI.ProfilePhotoMaker.UI/src/app/services/admin.service.ts
@@ -51,6 +51,20 @@ export interface AdminCreditPurchaseHistoryDto {
   completedAt: string | null;
 }
 
+export interface AdminPackageEntitlementDto {
+  id: number;
+  packageCode: string;
+  packageName: string;
+  status: string;
+  remainingCandidates: number;
+  remainingRefinements: number;
+  remainingPremiumAugmentations: number;
+  platformExportKitAvailable: boolean;
+  activatedAt: string | null;
+  consumedAt: string | null;
+  expiresAt: string | null;
+}
+
 export interface AdminRecentImageDto {
   id: number;
   imageUrl: string;
@@ -59,6 +73,10 @@ export interface AdminRecentImageDto {
   createdAt: string;
   isGenerated: boolean;
   isOriginalUpload: boolean;
+  provider: string | null;
+  providerModel: string | null;
+  generationStatus: string | null;
+  failureReason: string | null;
 }
 
 export interface AdminUserActivityDto {
@@ -86,6 +104,7 @@ export interface AdminUserDiagnosticsDto {
   user: AdminUserDetailDto;
   metrics: AdminUserMetricsDto;
   recentPurchases: AdminCreditPurchaseHistoryDto[];
+  packageEntitlements: AdminPackageEntitlementDto[];
   recentImages: AdminRecentImageDto[];
   activityHistory: AdminUserActivityDto[];
   recentAdminActions: AdminUserAdminActionDto[];
@@ -141,6 +160,84 @@ export interface AdminDashboardDto {
   totalCreditsOutstanding: number;
   totalCreditsPurchased: number;
   activeCoupons: number;
+}
+
+export interface AdminProductHealthDto {
+  window: string;
+  fromUtc: string;
+  toUtc: string;
+  funnel: AdminProductFunnelDto;
+  packageMix: AdminPackageMixDto[];
+  packageFulfillment: AdminPackageFulfillmentDto;
+  providerHealth: AdminProviderHealthDto[];
+  failureQueue: AdminFailureQueueDto;
+  replicateRetirement: AdminReplicateRetirementDto;
+}
+
+export interface AdminProductFunnelDto {
+  uploads: number;
+  successfulPreviewGenerations: number;
+  paidPackagePurchases: number;
+  starterPurchases: number;
+  proPurchases: number;
+  exportDownloads: number | null;
+  exportDownloadsAvailable: boolean;
+  medianGenerationTimeMs: number | null;
+  p95GenerationTimeMs: number | null;
+  generationLatencyAvailable: boolean;
+  previewGenerationSuccessRate: number | null;
+  previewGenerationSuccessRateAvailable: boolean;
+  previewToPaidConversionRate: number | null;
+  previewToPaidConversionRateAvailable: boolean;
+}
+
+export interface AdminPackageMixDto {
+  code: string;
+  name: string;
+  purchases: number;
+  revenueProxy: number;
+}
+
+export interface AdminPackageFulfillmentDto {
+  activeEntitlements: number;
+  consumedEntitlements: number;
+  expiredEntitlements: number;
+  refundedEntitlements: number;
+  remainingCandidates: number;
+  remainingRefinements: number;
+  remainingPremiumAugmentations: number;
+  exportKitsAvailable: number;
+}
+
+export interface AdminProviderHealthDto {
+  provider: string;
+  model: string;
+  generatedImages: number;
+  failedImages: number;
+  failureRate: number;
+}
+
+export interface AdminFailureQueueDto {
+  failedGenerations: number;
+  topReasons: AdminFailureReasonDto[];
+}
+
+export interface AdminFailureReasonDto {
+  reason: string;
+  count: number;
+}
+
+export interface AdminReplicateRetirementDto {
+  openAiGeneratedImages: number;
+  replicateGeneratedImages: number;
+  replicateUsageShare: number;
+  latencySignalAvailable: boolean;
+  fallbackGeneratedImages: number;
+  fallbackUseSignalAvailable: boolean;
+  advancedPhotoshootRequests: number;
+  advancedPhotoshootUsageSignalAvailable: boolean;
+  qualityComplaintSignalAvailable: boolean;
+  recommendation: string;
 }
 
 export interface PaginatedResult<T> {
@@ -241,5 +338,12 @@ export class AdminService extends BaseHttpService {
 
   getDashboard(): Observable<AdminDashboardDto> {
     return this.get<AdminDashboardDto>('admin/dashboard', { withCredentials: true });
+  }
+
+  getProductHealth(window = '7d'): Observable<AdminProductHealthDto> {
+    return this.get<AdminProductHealthDto>(
+      `admin/product-health?window=${encodeURIComponent(window)}`,
+      { withCredentials: true }
+    );
   }
 }

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,11 @@ An optional secondary area for non-professional transformations such as cartoon,
 
 The internal accounting mechanism for provider cost, package consumption, refunds, and admin/debug visibility. It should not be part of the primary user-facing pricing language.
 
+## Signup credit grant
+
+A legacy onboarding credit balance given to new users before the outcome-package pivot; new signups should receive a Free Preview path instead.
+_Avoid_: Free credits, welcome credits.
+
 ## Outfit upgrade
 
 A premium augmentation that changes visible clothing into role-appropriate professional attire while preserving identity and avoiding credential impersonation, sexualized clothing, drastic body changes, or status deception.
@@ -57,6 +62,21 @@ A non-generative post-generation edit applied to a final result, such as crop, z
 ## Photo workspace
 
 The user-facing workspace for a profile photo package. It contains the source photo, generated variants, scores, selected best shot, refinements, premium augmentations, platform exports, and package download. It replaces gallery as the primary user-facing concept.
+
+## Product health
+
+The operational view of whether the profile-photo workflow is converting, generating successfully, fulfilling package entitlements, and controlling provider cost.
+_Avoid_: Admin dashboard when referring specifically to pivot funnel and generation health.
+
+## Product funnel
+
+The measurable path from source photo upload to Free Preview generation, paid outcome package purchase, and platform export download.
+_Avoid_: Sales funnel when referring to in-product workflow conversion.
+
+## Package fulfillment
+
+The completion state of a package entitlement as candidates, refinements, premium augmentations, best-shot selection, and platform exports are consumed.
+_Avoid_: Credit usage when referring to user-facing package completion.
 
 ## Platform export kit
 
@@ -100,3 +120,5 @@ The legacy implementation behind the advanced custom photoshoot pack. It remains
 - A **Portrait style** is classified by frontend-derived metadata from the existing active style name into a recommended professional group, a more styles group, or a fun styles group until merchandising metadata moves server-side.
 - A **Creative style pack** contains styles classified as fun and remains separate from professional **Portrait styles**.
 - A **Professional profile photo package** contains one or more generated candidates from an **Instant headshot** plus optional **Photo adjustment**, **Best shot selector**, **Premium augmentation**, and **Platform export kit**.
+- **Product health** observes the **Product funnel** and **Package fulfillment** without replacing account operations.
+- **Package fulfillment** belongs to exactly one **Package entitlement**.

--- a/docs/admin-dashboard-pivot-review-2026-06-09.md
+++ b/docs/admin-dashboard-pivot-review-2026-06-09.md
@@ -1,0 +1,224 @@
+# Admin dashboard pivot review — 2026-06-09
+
+## Scope
+
+Reviewed admin dashboard surfaces against the current product pivot from credit/headshot-volume mechanics toward instant profile-photo workflow outcomes, preview-first upgrade, and outcome packages.
+
+Reviewed files:
+
+- `CONTEXT.md`
+- `docs/openai-images-2-pivot-implementation-plan.md`
+- `docs/adr/0001-profile-photo-workflow-outcomes-over-headshot-volume.md`
+- `docs/adr/0002-instant-portrait-styles-with-existing-prompts.md`
+- `docs/adr/0003-preview-first-upgrade-flow-with-candidate-reuse.md`
+- `AI.ProfilePhotoMaker.UI/src/app/admin/admin-dashboard/admin-dashboard.component.html`
+- `AI.ProfilePhotoMaker.UI/src/app/admin/admin-user-detail/admin-user-detail.component.html`
+- `AI.ProfilePhotoMaker.API/Models/DTOs/AdminDtos.cs`
+- `AI.ProfilePhotoMaker.API/Services/AdminService.cs`
+
+## Current admin dashboard state
+
+The admin dashboard is still a general operations panel:
+
+- Total users
+- Active users
+- Credits outstanding
+- Credits purchased
+- Active coupons
+- Quick links to users, coupons, audit log, and campaigns
+
+The backend dashboard DTO currently exposes only:
+
+- `TotalUsers`
+- `ActiveUsers`
+- `TotalCreditsOutstanding`
+- `TotalCreditsPurchased`
+- `ActiveCoupons`
+
+User diagnostics show useful account-level facts:
+
+- Credits
+- Usage balance
+- Last activity
+- Total / uploaded / generated images
+- Purchases
+- Last upload / generation
+- Recent images
+- Recent purchases
+- Credit history
+- Activity history
+- Recent admin actions
+
+## Pivot requirements that affect admin
+
+The pivot changes what operators need to observe:
+
+- Product is now outcome-package led, not raw headshot-volume led.
+- Free Preview is the primary entry point.
+- Starter and Pro packages are the paid conversion path.
+- Free Preview candidates can be promoted into paid candidates to reduce provider cost.
+- OpenAI instant generation is now primary; Replicate custom training is secondary / advanced.
+- Operators need enough telemetry to decide whether Replicate can be retired.
+- Metrics called out in pivot docs include upload-to-generation conversion, generation success rate, generation latency, cost per successful output, retry/regeneration rate, download rate, purchase conversion rate, and support/contact rate for quality complaints.
+
+## Findings
+
+### 1. Dashboard KPIs are no longer product-aligned
+
+Current KPIs are credit/account/admin-operation oriented. They do not answer the pivot's core operating questions:
+
+- Are Free Preview users converting to Starter/Pro?
+- Which outcome packages sell?
+- Are previews being promoted successfully?
+- Is OpenAI generation succeeding quickly enough?
+- Is provider cost improving after preview reuse?
+- Is Replicate usage low enough to retire or reposition?
+
+### 2. Credits remain over-emphasized
+
+Credits are still useful for support and legacy compatibility, but the pivot language is outcome packages and package entitlements. The top-level dashboard still makes credits two of five primary metrics.
+
+The legacy 25-credit grant for each new signup also conflicts with the Free Preview onboarding path. New users should enter through Free Preview, not through a generic credit balance.
+
+Recommended direction: remove the 25-credit signup grant, keep credits in user diagnostics and finance/support sections, and replace top-level credit KPIs with package / funnel metrics.
+
+### 3. No outcome-package admin visibility exists
+
+Outcome package concepts exist in the domain model and docs, but admin overview does not surface:
+
+- Active package definitions
+- Free Preview / Starter / Pro purchase counts
+- Package entitlement status counts
+- Conversion by package
+- Upgrade path from preview to paid
+- Package fulfillment health
+
+### 4. No provider/model operations visibility exists on overview
+
+Pivot docs mark admin/debug visibility for provider/model as done, but the main dashboard does not expose provider split or model health. Operators still cannot quickly compare OpenAI vs Replicate usage from the dashboard.
+
+### 5. User diagnostics need package context
+
+User detail shows purchases and images, but the labels still center on credits, uploads, generations, and usage balance. For pivot-era support, each user detail page should clearly show:
+
+- Current package entitlement(s)
+- Free Preview status
+- Starter/Pro upgrade status
+- Candidate count generated / included
+- Refinements used / included
+- Whether preview candidate was reused/promoted
+- Provider/model used for recent generations
+- Watermark/export eligibility
+
+### 6. Campaigns and coupons may need segmentation updates
+
+Campaigns and coupons remain relevant, but pivot-specific segments are likely needed:
+
+- Preview generated but not upgraded
+- Uploaded but generation failed
+- Starter purchased but unused refinements remain
+- Pro users with unused augmentations
+- Advanced training users / Replicate users
+- Quality complaint or failed generation cohorts
+
+## Recommended changes
+
+### P0 — Add product-pivot KPI strip to admin overview
+
+Replace or supplement current metrics with:
+
+1. Free Preview starts, last 7 days
+2. Successful preview generations, last 7 days
+3. Preview-to-paid conversion rate
+4. Starter purchases, last 7 days
+5. Pro purchases, last 7 days
+6. Generation success rate
+7. Median / p95 generation time
+8. OpenAI vs Replicate usage split
+
+Keep total users and active users. Move credits purchased/outstanding below the fold or into finance/support.
+
+### P1 — Add outcome package health panel
+
+Add an overview panel showing:
+
+- Active outcome packages
+- Entitlements by status
+- Package revenue / purchase counts by package
+- Candidate fulfillment status
+- Refinements used vs included
+- Preview promotions / reuse count
+
+### P1 — Add provider/model health panel
+
+Add operational visibility:
+
+- Generation count by provider and model
+- Failure rate by provider
+- Median / p95 latency by provider
+- Retry/regeneration rate
+- Cost estimate per successful output if available
+
+This directly supports the pivot done criterion: decide whether to retire Replicate based on data.
+
+### P1 — Update user diagnostics for package support
+
+Add package-centric blocks to the user detail page:
+
+- Package entitlements
+- Preview status
+- Upgrade path
+- Candidate/refinement/augmentation consumption
+- Export kit eligibility
+- Recent generation provider/model
+- Recent failures with reason codes
+
+### P2 — Update copy and hierarchy
+
+Change admin overview subtitle from:
+
+> Manage users, credits, coupons, and operational audits.
+
+To pivot-aligned language such as:
+
+> Monitor preview-to-package conversion, generation health, users, promotions, and operational audits.
+
+Change quick action copy for User Management from credit-balance centered to support/diagnostics centered.
+
+### P2 — Add package-aware campaign/coupon shortcuts
+
+Add quick links or filters for:
+
+- Preview abandoners
+- Failed generation recovery
+- Starter upgrade candidates
+- Pro upsell candidates
+- Unused entitlement reminders
+
+## Suggested implementation shape
+
+Backend:
+
+- Extend `AdminDashboardDto` with pivot metrics, or create `AdminProductDashboardDto` to avoid bloating legacy admin stats.
+- Remove the legacy 25-credit default from new-user/profile creation paths (`UserProfile.Credits` default and registration-created profiles currently assign 25 credits).
+- Add queries against outcome package definitions, user entitlements, credit purchases, image generation metadata, and activity/usage logs.
+- Keep existing fields for compatibility with current UI tests.
+
+Frontend:
+
+- Add a new `Product Health` section above or beside existing metrics.
+- Rename existing `Credits Purchased` / `Credits Outstanding` cards to a secondary `Finance / Credits` section.
+- Add package/provider panels with empty states for environments without enough telemetry.
+
+Testing:
+
+- Add API tests for zero-data dashboard state.
+- Add API tests for Free Preview / Starter / Pro counts.
+- Add API tests for provider split and failed generation counts.
+- Add UI tests for empty state and populated product-health state.
+
+## Recommendation
+
+Yes, admin dashboard changes are needed after the pivot.
+
+The current admin dashboard is safe for basic account operations, but it is not sufficient for operating the pivoted product. It should be updated to make preview-to-package conversion, package entitlement health, and generation provider/model health first-class admin signals.

--- a/docs/admin-product-health-grill-decisions-2026-06-09.md
+++ b/docs/admin-product-health-grill-decisions-2026-06-09.md
@@ -1,0 +1,87 @@
+# Admin product health grill decisions — 2026-06-09
+
+## Decisions
+
+1. Scope is **whole admin area plus a new Product Health admin page**.
+   - Keep existing admin operations dashboard useful for users, credits, coupons, campaigns, and audit logs.
+   - Add Product Health as the pivot-specific surface for funnel, package, and provider health.
+
+2. Product Health serves **both founder/operator and support/debug decisions**.
+   - First section: business funnel and pivot viability.
+   - Second section: operational health and support/debug queues.
+
+3. Default time window is **selectable, default 7 days**.
+   - Include 24h, 7d, 30d, and all-time.
+   - Default 7d balances low-volume product signal with operational recency.
+
+4. Canonical V1 funnel is **upload → preview generated → paid package purchased → export downloaded**.
+   - Do not make visit/landing the V1 funnel start because analytics/cookie-consent reliability is a separate concern.
+   - Add landing/CTA metrics later when analytics trust is established.
+
+5. Top Product Health metrics:
+   - Uploads
+   - Successful Free Preview generations
+   - Preview generation success rate
+   - Preview-to-paid conversion rate
+   - Starter purchases
+   - Pro purchases
+   - Export downloads
+   - Median / p95 generation time
+   - OpenAI vs Replicate usage split
+
+6. Existing `/admin/dashboard` changes:
+   - Keep total users and active users.
+   - Move credit metrics lower or into a finance/support group.
+   - Add a small Product Health summary card and link.
+   - Update copy away from credit-first positioning.
+
+7. Whole admin area changes:
+   - User list: add pivot-aware filters later, not V1 table bloat.
+   - User detail: add package entitlements, preview state, upgrade path, candidate/refinement/augmentation consumption, export eligibility, provider/model, and recent generation failures.
+   - Campaigns: add segments for preview abandoners, failed generation recovery, unused entitlements, Starter upgrade candidates, and Pro upsell candidates.
+   - Coupons: connect coupons to outcome package promotion where supported.
+   - Audit log: ensure package/entitlement/admin credit adjustments remain traceable.
+
+8. Product Health page sections:
+   - Funnel health
+   - Package mix and revenue proxy
+   - Package fulfillment
+   - Provider/model health
+   - Failure/support queues
+   - Replicate retirement signal
+
+9. Replicate retirement signal requires:
+   - OpenAI success rate acceptable
+   - OpenAI median/p95 latency acceptable
+   - Low advanced custom photoshoot usage
+   - Low fallback use
+   - Quality/support complaints not worse than baseline
+
+10. V1 implementation should prefer existing persisted data and structured logs before adding a new analytics dependency.
+    - If a metric cannot be computed reliably, show unavailable/empty state rather than fake precision.
+
+11. New signups should no longer receive the legacy **25-credit signup grant**.
+    - Free Preview replaces free signup credits as the onboarding value path.
+    - Existing paid package and admin credit-adjustment flows remain available.
+    - Product Health should expose zero-credit/new-user states clearly so support can distinguish intentional no-grant behavior from credit provisioning bugs.
+
+## Documentation updates made
+
+- Added glossary terms to `CONTEXT.md`:
+  - Product health
+  - Product funnel
+  - Package fulfillment
+- Added ADR:
+  - `docs/adr/0004-product-health-beside-admin-operations.md`
+
+## Implementation recommendation
+
+Build in this order:
+
+1. Backend DTO and service for Product Health summary using existing data.
+2. New `/admin/product-health` route and nav item.
+3. Product Health page with time-window selector and empty states.
+4. Update existing admin overview copy and add Product Health summary card.
+5. Remove the legacy 25-credit signup grant from new-user creation paths.
+6. Extend user detail with package entitlement, generation provider context, and intentional no-grant/zero-credit state.
+7. Add campaign/user filters once the underlying query contracts are stable.

--- a/docs/adr/0004-product-health-beside-admin-operations.md
+++ b/docs/adr/0004-product-health-beside-admin-operations.md
@@ -1,0 +1,5 @@
+# Product health lives beside admin operations
+
+Status: accepted
+
+The admin pivot update will cover the whole admin area while adding a separate Product Health admin page instead of replacing the existing operations dashboard. This preserves support/account workflows while giving the pivot its own funnel, package-fulfillment, and provider-health surface; the trade-off is one more admin page, but it prevents credit/user operations from obscuring whether the new outcome-package product is working.


### PR DESCRIPTION
## Summary
- Add admin Product Health API and Angular page with funnel, package, provider, failure, and Replicate retirement signals
- Remove signup/profile free-credit grants so Free Preview is the onboarding path
- Extend admin user diagnostics with package entitlements and generation provider/failure context
- Document Product Health glossary/ADR and pivot decisions

## Verification
- dotnet build AI.ProfilePhotoMaker.API/AI.ProfilePhotoMaker.API.csproj --no-restore
- dotnet test AI.ProfilePhotoMaker.API.Tests/AI.ProfilePhotoMaker.API.Tests.csproj --no-restore --filter AdminServiceTests
- cd AI.ProfilePhotoMaker.UI && npm run lint:errors-only
- cd AI.ProfilePhotoMaker.UI && npm run build:dev
- Secret scan of staged diff: no matches

## Deployment notes / rollback
- No DB migration included; uses existing ProcessedImages, UserPackageEntitlements, ModelCreationRequests data
- Deploy via existing Simple Deploy workflow/local build helper
- Rollback by reverting commit 59b93c2 if Product Health admin surface misbehaves