### PR TITLE
Fix admin user detail test fixture

### DIFF
--- a/AI.ProfilePhotoMaker.UI/src/app/admin/admin-user-detail/admin-user-detail.component.spec.ts
+++ b/AI.ProfilePhotoMaker.UI/src/app/admin/admin-user-detail/admin-user-detail.component.spec.ts
@@ -40,6 +40,7 @@ describe('AdminUserDetailComponent', () => {
       hasUsageHistory: true,
     },
     recentPurchases: [],
+    packageEntitlements: [],
     recentImages: [],
     activityHistory: [],
     recentAdminActions: [],


### PR DESCRIPTION
## Summary
- Add packageEntitlements to the admin user detail spec fixture so CI frontend tests compile after Product Health diagnostics additions.

## Verification
- cd AI.ProfilePhotoMaker.UI && npm test -- --watch=false --browsers=ChromeHeadless (TOTAL: 458 SUCCESS)
- dotnet build AI.ProfilePhotoMaker.API/AI.ProfilePhotoMaker.API.csproj --no-restore
- dotnet test AI.ProfilePhotoMaker.API.Tests/AI.ProfilePhotoMaker.API.Tests.csproj --no-restore --filter AdminServiceTests
- Secret scan of diff: no matches

## Deployment notes / rollback
- Test-only change; safe to deploy after merge.
- Rollback by reverting this commit if needed.